### PR TITLE
feat: ETag conditional requests + resource-based authorization + scalar VO route constraints

### DIFF
--- a/Api/src/2022-12-21/Controllers/HostsController.cs
+++ b/Api/src/2022-12-21/Controllers/HostsController.cs
@@ -1,0 +1,60 @@
+namespace BuberDinner._2022_12_21.Controllers;
+
+using System.Security.Claims;
+using Asp.Versioning;
+using BuberDinner.Api._2022_12_21.Models.Hosts;
+using BuberDinner.Domain.User.ValueObjects;
+using Mapster;
+using Mediator;
+using Microsoft.AspNetCore.Mvc;
+using Trellis.Asp;
+
+/// <summary>
+/// Register and manage Hosts. A Host is owned by the authenticated user;
+/// the owner relationship gates resource-based authorization on menu mutations.
+/// </summary>
+[ApiVersion("2022-10-01")]
+[Route("hosts")]
+[Consumes("application/json")]
+[Produces("application/json")]
+[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+[ProducesResponseType(StatusCodes.Status201Created)]
+public class HostsController : ControllerBase
+{
+    private readonly ISender _sender;
+
+    /// <summary>Initializes a new instance of <see cref="HostsController"/>.</summary>
+    /// <param name="sender">The Mediator <see cref="ISender"/> used to dispatch commands.</param>
+    public HostsController(ISender sender)
+    {
+        _sender = sender;
+    }
+
+    /// <summary>
+    /// Register a new Host owned by the authenticated user. The OwnerId is read from the JWT `sub`
+    /// claim (the same claim Trellis ClaimsActorProvider uses for Actor.Id).
+    /// </summary>
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
+    public async ValueTask<ActionResult<HostResponse>> CreateHost(
+        [FromBody] CreateHostRequest request,
+        CancellationToken cancellationToken)
+    {
+        var ownerIdString = HttpContext.User.FindFirst("sub")?.Value
+            ?? HttpContext.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (string.IsNullOrEmpty(ownerIdString))
+            return Unauthorized();
+
+        var ownerIdResult = UserId.TryCreate(ownerIdString);
+        if (ownerIdResult.IsFailure)
+            return Unauthorized();
+        var ownerId = ownerIdResult.GetValueOrThrow(nameof(ownerIdString));
+
+        return await request.ToCreateHostCommand(ownerId)
+            .BindAsync(command => _sender.Send(command, cancellationToken))
+            .ToHttpResponseAsync(
+                body: host => new HostResponse(host.Id.Value.ToString(), host.OwnerId.Value, host.DisplayName.Value),
+                configure: opts => opts.Created(host => $"/hosts/{host.Id.Value}"))
+            .AsActionResultAsync<HostResponse>();
+    }
+}

--- a/Api/src/2022-12-21/Controllers/MenusController.cs
+++ b/Api/src/2022-12-21/Controllers/MenusController.cs
@@ -2,15 +2,21 @@
 
 using Asp.Versioning;
 using BuberDinner.Api._2022_12_21.Models.Menus;
+using BuberDinner.Application.Menus.Queries;
+using BuberDinner.Domain.Host.ValueObject;
+using BuberDinner.Domain.Menu;
+using BuberDinner.Domain.Menu.ValueObject;
 using Mapster;
 using Mediator;
 using Microsoft.AspNetCore.Mvc;
+using Trellis;
+using Trellis.Asp;
 
 /// <summary>
 /// CRUD for menu.
 /// </summary>
 [ApiVersion("2022-10-01")]
-[Route("hosts/{hostId}/menus")]
+[Route("hosts/{hostId:HostId}/menus")]
 [Consumes("application/json")]
 [Produces("application/json")]
 [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -36,12 +42,54 @@ public class MenusController : ControllerBase
     /// <param name="hostId">The id of the host creating the menu</param>
     /// <returns>A <see cref="CreateMenuResponse"/> result containing the newly created menu</returns>
     [HttpPost("create")]
-    public async ValueTask<ActionResult<CreateMenuResponse>> CreateMenu(CreateMenuRequest request, string hostId) =>
+    public async ValueTask<ActionResult<CreateMenuResponse>> CreateMenu(CreateMenuRequest request, HostId hostId) =>
         await request
-            .ToCreateMenuCommand(hostId)
+            .ToCreateMenuCommand(hostId.Value.ToString())
             .BindAsync(command => _sender.Send(command))
             .ToHttpResponseAsync(
                 body: menu => menu.Adapt<CreateMenuResponse>(),
-                configure: opts => opts.Created(menu => $"/hosts/{hostId}/menus/{menu.Id}"))
+                configure: opts => opts.Created(menu => $"/hosts/{hostId.Value}/menus/{menu.Id}"))
             .AsActionResultAsync<CreateMenuResponse>();
+
+    /// <summary>
+    /// Get a menu. Emits a strong ETag so clients can revalidate with If-None-Match (304) or
+    /// fail-on-stale with If-Match (412). Per Cookbook Recipe 6.
+    /// </summary>
+    /// <param name="hostId">The id of the host that owns the menu.</param>
+    /// <param name="menuId">The id of the menu to retrieve.</param>
+    [HttpGet("{menuId:MenuId}")]
+    [ProducesResponseType(StatusCodes.Status304NotModified)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status412PreconditionFailed)]
+    public async ValueTask<ActionResult<MenuResponse>> GetMenu(HostId hostId, MenuId menuId) =>
+        await _sender.Send(new GetMenuQuery(menuId))
+            .ToHttpResponseAsync(
+                body: menu => menu.Adapt<MenuResponse>(),
+                configure: opts => opts
+                    .WithETag(menu => EntityTagValue.Strong(menu.ETag))
+                    .EvaluatePreconditions())
+            .AsActionResultAsync<MenuResponse>();
+
+    /// <summary>
+    /// Update a menu with full optimistic-concurrency protection. Requires an
+    /// <c>If-Match</c> header carrying the current ETag (RFC 9110 §13.1.1 + RFC 6585):
+    /// missing → 428 Precondition Required; stale → 412 Precondition Failed.
+    /// Resource-based authorization gates by Host ownership (Cookbook Recipes 7 + 23).
+    /// </summary>
+    [HttpPut("{menuId:MenuId}")]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status412PreconditionFailed)]
+    [ProducesResponseType(StatusCodes.Status428PreconditionRequired)]
+    public async ValueTask<ActionResult<MenuResponse>> UpdateMenu(
+        HostId hostId,
+        MenuId menuId,
+        [FromBody] UpdateMenuRequest request,
+        CancellationToken cancellationToken) =>
+        await request.ToUpdateMenuCommand(hostId, menuId, ETagHelper.ParseIfMatch(HttpContext.Request))
+            .BindAsync(command => _sender.Send(command, cancellationToken))
+            .ToHttpResponseAsync(
+                body: menu => menu.Adapt<MenuResponse>(),
+                configure: opts => opts.WithETag(menu => EntityTagValue.Strong(menu.ETag)))
+            .AsActionResultAsync<MenuResponse>();
 }

--- a/Api/src/2022-12-21/Controllers/MenusController.cs
+++ b/Api/src/2022-12-21/Controllers/MenusController.cs
@@ -62,7 +62,7 @@ public class MenusController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status412PreconditionFailed)]
     public async ValueTask<ActionResult<MenuResponse>> GetMenu(HostId hostId, MenuId menuId) =>
-        await _sender.Send(new GetMenuQuery(menuId))
+        await _sender.Send(new GetMenuQuery(hostId, menuId))
             .ToHttpResponseAsync(
                 body: menu => menu.Adapt<MenuResponse>(),
                 configure: opts => opts

--- a/Api/src/2022-12-21/Models/Hosts/CreateHostRequest.cs
+++ b/Api/src/2022-12-21/Models/Hosts/CreateHostRequest.cs
@@ -1,0 +1,21 @@
+namespace BuberDinner.Api._2022_12_21.Models.Hosts;
+
+using BuberDinner.Application.Hosts.Commands;
+using BuberDinner.Domain.User.ValueObjects;
+using NameClass = BuberDinner.Domain.Common.ValueObjects.Name;
+
+/// <summary>
+/// Request to register a new Host owned by the authenticated user.
+/// </summary>
+public record CreateHostRequest(string DisplayName)
+{
+    /// <summary>Validates the request and lifts it into a <see cref="CreateHostCommand"/>.</summary>
+    public Result<CreateHostCommand> ToCreateHostCommand(UserId ownerId) =>
+        NameClass.TryCreate(this.DisplayName)
+            .Bind(name => CreateHostCommand.TryCreate(ownerId, name));
+}
+
+/// <summary>
+/// Wire representation of a Host.
+/// </summary>
+public record HostResponse(string Id, string OwnerId, string DisplayName);

--- a/Api/src/2022-12-21/Models/Menus/MenuResponse.cs
+++ b/Api/src/2022-12-21/Models/Menus/MenuResponse.cs
@@ -1,0 +1,16 @@
+namespace BuberDinner.Api._2022_12_21.Models.Menus;
+
+/// <summary>
+/// Menu retrieval/response shape — used for GET /menus/{id} and PUT /menus/{id}.
+/// Same shape as <see cref="CreateMenuResponse"/>; declared separately so the OpenAPI
+/// contract distinguishes the read and write models.
+/// </summary>
+public record MenuResponse(
+    string Id,
+    string Name,
+    string Description,
+    decimal? AverageRating,
+    List<MenuSectionResponse> Sections,
+    string HostId,
+    List<string> DinnerIds,
+    List<string> MenuReviewIds);

--- a/Api/src/2022-12-21/Models/Menus/UpdateMenuRequest.cs
+++ b/Api/src/2022-12-21/Models/Menus/UpdateMenuRequest.cs
@@ -1,0 +1,22 @@
+namespace BuberDinner.Api._2022_12_21.Models.Menus;
+
+using BuberDinner.Application.Menus.Commands;
+using BuberDinner.Domain.Host.ValueObject;
+using BuberDinner.Domain.Menu.ValueObject;
+using DescriptionClass = BuberDinner.Domain.Common.ValueObjects.Description;
+using NameClass = BuberDinner.Domain.Common.ValueObjects.Name;
+
+/// <summary>
+/// Update-menu request body (PUT /hosts/{hostId}/menus/{menuId}).
+/// </summary>
+public record UpdateMenuRequest(string Name, string Description)
+{
+    /// <summary>
+    /// Validates the request fields and lifts them into an <see cref="UpdateMenuCommand"/>
+    /// carrying the parsed <c>If-Match</c> tokens for the handler to enforce.
+    /// </summary>
+    public Result<UpdateMenuCommand> ToUpdateMenuCommand(HostId hostId, MenuId menuId, EntityTagValue[]? ifMatch) =>
+        NameClass.TryCreate(this.Name)
+            .Combine(DescriptionClass.TryCreate(this.Description))
+            .Bind((name, description) => UpdateMenuCommand.TryCreate(hostId, menuId, name, description, ifMatch));
+}

--- a/Api/src/DependencyInjection.cs
+++ b/Api/src/DependencyInjection.cs
@@ -1,12 +1,19 @@
 ﻿namespace BuberDinner.Api;
 
 using System.Reflection;
+using BuberDinner.Application.Hosts.Authorization;
+using BuberDinner.Application.Menus.Commands;
+using BuberDinner.Domain.Host.ValueObject;
+using BuberDinner.Domain.Menu.ValueObject;
 using Mapster;
 using MapsterMapper;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
+using Trellis.Asp.Authorization;
+using Trellis.Asp.Routing;
+using Trellis.Mediator;
 
 internal static class DependencyInjection
 {
@@ -14,6 +21,20 @@ internal static class DependencyInjection
     {
         services.AddControllers();
         services.AddTrellisAspWithScalarValidation();
+
+        // Scalar value-object route constraints — let MVC bind `{hostId:HostId}` / `{menuId:MenuId}`
+        // straight into typed VOs at the boundary (instead of string-then-reparse-in-DTO).
+        services.AddTrellisRouteConstraint<HostId>(nameof(HostId));
+        services.AddTrellisRouteConstraint<MenuId>(nameof(MenuId));
+
+        // Resource-based authorization wiring: ClaimsActorProvider reads the JWT `sub` claim
+        // and the SharedResourceLoaderById<Host, HostId> in the Application assembly authorizes
+        // any command implementing IAuthorizeResource<Host> + IIdentifyResource<Host, HostId>.
+        services.AddClaimsActorProvider(opts => opts.ActorIdClaim = "sub");
+        services.AddResourceAuthorization(
+            typeof(UpdateMenuCommand).Assembly,   // Application — commands + IAuthorizeResource implementations
+            typeof(HostResourceLoader).Assembly); // Same assembly today; named for clarity / future ACL split
+
         services.AddMappings();
         services.AddApiVersioning(
                     options =>

--- a/Api/tests/2022-12-21/MenuEtagAndAuthTests.cs
+++ b/Api/tests/2022-12-21/MenuEtagAndAuthTests.cs
@@ -1,0 +1,230 @@
+namespace BuberDinner.Api.Tests._2022_12_21;
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit.Priority;
+
+/// <summary>
+/// Integration tests for the resource-authorization and ETag/precondition behaviour added by PR 1:
+///   * GET   /hosts/{hostId:HostId}/menus/{menuId:MenuId} — Cookbook Recipe 6 (WithETag + EvaluatePreconditions)
+///   * PUT   /hosts/{hostId:HostId}/menus/{menuId:MenuId} — Cookbook Recipe 23 (RequireETag in handler chain)
+///   * POST  /hosts                                       — establishes the Host that gates auth on PUT
+///
+/// Each test runs end-to-end through the WebApplicationFactory and shares no state with peers
+/// (each test registers a fresh user so the in-memory User repo stays consistent).
+/// </summary>
+[TestCaseOrderer(PriorityOrderer.Name, PriorityOrderer.Assembly)]
+public class MenuEtagAndAuthTests
+    : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public MenuEtagAndAuthTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact, Priority(2)]
+    public async Task Create_host_returns_201_with_owner_id()
+    {
+        var (client, _, userId) = await NewAuthenticatedClient();
+
+        var (status, body) = await CreateHostAsync(client, "Bistro 33");
+
+        status.Should().Be(HttpStatusCode.Created);
+        body!.Id.Should().NotBeNullOrEmpty();
+        body.OwnerId.Should().Be(userId);
+        body.DisplayName.Should().Be("Bistro 33");
+    }
+
+    [Fact, Priority(2)]
+    public async Task Get_menu_returns_200_with_strong_etag()
+    {
+        var (client, _, _) = await NewAuthenticatedClient();
+        var hostId = (await CreateHostAsync(client, "Eggs Inc")).Body!.Id;
+        var menuId = await CreateMenuAsync(client, hostId);
+
+        var response = await client.GetAsync(MenuUrl(hostId, menuId));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.ETag.Should().NotBeNull();
+        response.Headers.ETag!.IsWeak.Should().BeFalse("Recipe 6 emits a strong ETag");
+        response.Headers.ETag.Tag.Should().StartWith("\"").And.EndWith("\"");
+    }
+
+    [Fact, Priority(2)]
+    public async Task Get_menu_with_matching_if_none_match_returns_304()
+    {
+        var (client, _, _) = await NewAuthenticatedClient();
+        var hostId = (await CreateHostAsync(client, "Brunch Co")).Body!.Id;
+        var menuId = await CreateMenuAsync(client, hostId);
+
+        var firstGet = await client.GetAsync(MenuUrl(hostId, menuId));
+        var etag = firstGet.Headers.ETag!.Tag;
+
+        var conditional = new HttpRequestMessage(HttpMethod.Get, MenuUrl(hostId, menuId));
+        conditional.Headers.TryAddWithoutValidation("If-None-Match", etag);
+        var notModified = await client.SendAsync(conditional);
+
+        notModified.StatusCode.Should().Be(HttpStatusCode.NotModified);
+        notModified.Headers.ETag!.Tag.Should().Be(etag);
+    }
+
+    [Fact, Priority(2)]
+    public async Task Put_menu_without_if_match_returns_428()
+    {
+        var (client, _, _) = await NewAuthenticatedClient();
+        var hostId = (await CreateHostAsync(client, "No-Precondition Cafe")).Body!.Id;
+        var menuId = await CreateMenuAsync(client, hostId);
+
+        var put = new HttpRequestMessage(HttpMethod.Put, MenuUrl(hostId, menuId))
+        {
+            Content = JsonBody(new { name = "Updated", description = "Updated description" })
+        };
+        var response = await client.SendAsync(put);
+
+        response.StatusCode.Should().Be(HttpStatusCode.PreconditionRequired);
+    }
+
+    [Fact, Priority(2)]
+    public async Task Put_menu_with_stale_if_match_returns_412()
+    {
+        var (client, _, _) = await NewAuthenticatedClient();
+        var hostId = (await CreateHostAsync(client, "Stale Co")).Body!.Id;
+        var menuId = await CreateMenuAsync(client, hostId);
+
+        var put = new HttpRequestMessage(HttpMethod.Put, MenuUrl(hostId, menuId))
+        {
+            Content = JsonBody(new { name = "Updated", description = "Updated description" })
+        };
+        put.Headers.TryAddWithoutValidation("If-Match", "\"deadbeefdeadbeefdeadbeefdeadbeef\"");
+        var response = await client.SendAsync(put);
+
+        response.StatusCode.Should().Be(HttpStatusCode.PreconditionFailed);
+    }
+
+    [Fact, Priority(2)]
+    public async Task Put_menu_with_valid_if_match_returns_200_and_new_etag()
+    {
+        var (client, _, _) = await NewAuthenticatedClient();
+        var hostId = (await CreateHostAsync(client, "Fresh Co")).Body!.Id;
+        var menuId = await CreateMenuAsync(client, hostId);
+
+        var get = await client.GetAsync(MenuUrl(hostId, menuId));
+        var originalEtag = get.Headers.ETag!.Tag;
+
+        var put = new HttpRequestMessage(HttpMethod.Put, MenuUrl(hostId, menuId))
+        {
+            Content = JsonBody(new { name = "Brunch v2", description = "Updated brunch menu" })
+        };
+        put.Headers.TryAddWithoutValidation("If-Match", originalEtag);
+        var response = await client.SendAsync(put);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.ETag.Should().NotBeNull();
+        response.Headers.ETag!.Tag.Should().NotBe(originalEtag, "the handler bumps the ETag after a successful update");
+
+        var body = await response.Content.ReadAsAsync<MenuBody>();
+        body!.Name.Should().Be("Brunch v2");
+        body.Description.Should().Be("Updated brunch menu");
+    }
+
+    [Fact, Priority(2)]
+    public async Task Put_menu_as_different_user_returns_403_forbidden()
+    {
+        // Owner registers + creates Host + Menu
+        var (ownerClient, _, _) = await NewAuthenticatedClient();
+        var hostId = (await CreateHostAsync(ownerClient, "Owned by user A")).Body!.Id;
+        var menuId = await CreateMenuAsync(ownerClient, hostId);
+
+        var get = await ownerClient.GetAsync(MenuUrl(hostId, menuId));
+        var etag = get.Headers.ETag!.Tag;
+
+        // A SECOND user logs in (separate token) and attempts to PUT the same menu.
+        var (intruderClient, _, _) = await NewAuthenticatedClient();
+        var put = new HttpRequestMessage(HttpMethod.Put, MenuUrl(hostId, menuId))
+        {
+            Content = JsonBody(new { name = "Pwned", description = "Updated by a different user" })
+        };
+        put.Headers.TryAddWithoutValidation("If-Match", etag);
+        var response = await intruderClient.SendAsync(put);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        // ProblemDetails.code is set to "menus.owner" by UpdateMenuCommand.IAuthorizeResource<Host>
+        var problem = await response.Content.ReadAsAsync<ProblemDetailsWithCode>();
+        problem!.Status.Should().Be(403);
+        problem.Code.Should().Be("menus.owner");
+    }
+
+    // ---------------- helpers ----------------
+
+    private static string MenuUrl(string hostId, string menuId) =>
+        $"hosts/{hostId}/menus/{menuId}?api-version=2022-10-01";
+
+    private async Task<(HttpClient client, string token, string userId)> NewAuthenticatedClient()
+    {
+        var userId = $"user_{Guid.NewGuid():N}".Substring(0, 16);
+        var client = _factory.CreateClient();
+        var body = $$"""
+            {
+              "userId": "{{userId}}",
+              "firstName": "First",
+              "lastName": "Last",
+              "email": "{{userId}}@example.com",
+              "password": "SuperStr0ngPa$$word"
+            }
+            """;
+        var response = await client.PostAsync("authentication/register",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+        response.EnsureSuccessStatusCode();
+        var token = (await response.Content.ReadAsAsync<RegisterReply>())!.Token;
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return (client, token, userId);
+    }
+
+    private static async Task<(HttpStatusCode Status, HostBody? Body)> CreateHostAsync(HttpClient client, string displayName)
+    {
+        var json = JsonSerializer.Serialize(new { displayName });
+        var response = await client.PostAsync("hosts?api-version=2022-10-01",
+            new StringContent(json, Encoding.UTF8, "application/json"));
+        var body = response.IsSuccessStatusCode ? await response.Content.ReadAsAsync<HostBody>() : null;
+        return (response.StatusCode, body);
+    }
+
+    private static async Task<string> CreateMenuAsync(HttpClient client, string hostId)
+    {
+        var json = """
+            {
+              "name": "Brunch",
+              "description": "Sunday brunch menu",
+              "sections": [
+                {
+                  "name": "Eggs",
+                  "description": "Egg dishes",
+                  "items": [ { "name": "Omelette", "description": "Three-egg omelette" } ]
+                }
+              ]
+            }
+            """;
+        var response = await client.PostAsync($"hosts/{hostId}/menus/create?api-version=2022-10-01",
+            new StringContent(json, Encoding.UTF8, "application/json"));
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var menu = await response.Content.ReadAsAsync<MenuBody>();
+        return menu!.Id;
+    }
+
+    private static StringContent JsonBody(object payload) =>
+        new(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+    private sealed record RegisterReply(string Token);
+
+    private sealed record HostBody(string Id, string OwnerId, string DisplayName);
+
+    private sealed record MenuBody(string Id, string Name, string Description);
+
+    private sealed record ProblemDetailsWithCode(int Status, string? Code, string? Kind);
+}

--- a/Api/tests/2022-12-21/MenuEtagAndAuthTests.cs
+++ b/Api/tests/2022-12-21/MenuEtagAndAuthTests.cs
@@ -56,6 +56,22 @@ public class MenuEtagAndAuthTests
     }
 
     [Fact, Priority(2)]
+    public async Task Get_menu_under_wrong_host_returns_404()
+    {
+        var (client, _, _) = await NewAuthenticatedClient();
+        var realHostId = (await CreateHostAsync(client, "Real Owner")).Body!.Id;
+        var menuId = await CreateMenuAsync(client, realHostId);
+
+        // A different (well-formed) HostId that happens to not own the menu.
+        var foreignHostId = Guid.NewGuid().ToString();
+
+        var response = await client.GetAsync(MenuUrl(foreignHostId, menuId));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "the hierarchical route enforces that the menu must belong to the named host");
+    }
+
+    [Fact, Priority(2)]
     public async Task Get_menu_with_matching_if_none_match_returns_304()
     {
         var (client, _, _) = await NewAuthenticatedClient();

--- a/Api/tests/2022-12-21/MenusControllerTests.cs
+++ b/Api/tests/2022-12-21/MenusControllerTests.cs
@@ -145,7 +145,9 @@ public class MenusControllerTests
         // on the controller and the framework's ToHttpResponseAsync(..., opts => opts.Created(...)) builder).
         response.StatusCode.Should().Be(HttpStatusCode.Created);
         response.Headers.Location.Should().NotBeNull();
-        response.Headers.Location!.OriginalString.Should().StartWith("/hosts/4F82063C-AE9D-4F5B-B676-DD781C14EFA0/menus/");
+        // GUIDs are case-insensitive per RFC 4122 §3; the `:HostId` route constraint normalises
+        // them to lowercase via Guid.ToString("D"). Compare case-insensitively.
+        response.Headers.Location!.OriginalString.Should().StartWithEquivalentOf("/hosts/4F82063C-AE9D-4F5B-B676-DD781C14EFA0/menus/");
         await ValidateMenuResponse(response);
     }
 

--- a/Application/src/BuberDinner.Application.csproj
+++ b/Application/src/BuberDinner.Application.csproj
@@ -8,6 +8,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Trellis.Mediator" />
+    <PackageReference Include="Trellis.Http.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Application/src/Hosts/Authorization/HostResourceLoader.cs
+++ b/Application/src/Hosts/Authorization/HostResourceLoader.cs
@@ -1,0 +1,32 @@
+namespace BuberDinner.Application.Hosts.Authorization;
+
+using System.Threading;
+using System.Threading.Tasks;
+using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.Host.Entities;
+using BuberDinner.Domain.Host.ValueObject;
+using Trellis.Authorization;
+
+/// <summary>
+/// Loads a <see cref="Host"/> by <see cref="HostId"/> for the resource-authorization pipeline.
+/// Any command implementing both <c>IAuthorizeResource&lt;Host&gt;</c> and
+/// <c>IIdentifyResource&lt;Host, HostId&gt;</c> reuses this shared loader — no per-command
+/// loader required (per Cookbook Recipe 7 and trellis-api-authorization.md:333).
+/// </summary>
+public sealed class HostResourceLoader : SharedResourceLoaderById<Host, HostId>
+{
+    private readonly IRepository<Host> _hostRepository;
+
+    public HostResourceLoader(IRepository<Host> hostRepository)
+    {
+        _hostRepository = hostRepository;
+    }
+
+    public override async Task<Result<Host>> GetByIdAsync(HostId id, CancellationToken cancellationToken)
+    {
+        var host = await _hostRepository.FindById(id.Value.ToString(), cancellationToken);
+        if (host is null)
+            return Result.Fail<Host>(new Error.NotFound(ResourceRef.For<Host>(id)));
+        return Result.Ok(host);
+    }
+}

--- a/Application/src/Hosts/Commands/CreateHostCommand.cs
+++ b/Application/src/Hosts/Commands/CreateHostCommand.cs
@@ -1,0 +1,21 @@
+namespace BuberDinner.Application.Hosts.Commands;
+
+using BuberDinner.Domain.Common.ValueObjects;
+using BuberDinner.Domain.Host.Entities;
+using BuberDinner.Domain.User.ValueObjects;
+using Mediator;
+
+public sealed class CreateHostCommand : IRequest<Result<Host>>
+{
+    public UserId OwnerId { get; }
+    public Name DisplayName { get; }
+
+    public static Result<CreateHostCommand> TryCreate(UserId ownerId, Name displayName) =>
+        Result.Ok(new CreateHostCommand(ownerId, displayName));
+
+    private CreateHostCommand(UserId ownerId, Name displayName)
+    {
+        OwnerId = ownerId;
+        DisplayName = displayName;
+    }
+}

--- a/Application/src/Hosts/Commands/CreateHostCommandHandler.cs
+++ b/Application/src/Hosts/Commands/CreateHostCommandHandler.cs
@@ -1,0 +1,21 @@
+namespace BuberDinner.Application.Hosts.Commands;
+
+using System.Threading;
+using System.Threading.Tasks;
+using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.Host.Entities;
+using Mediator;
+
+public sealed class CreateHostCommandHandler : IRequestHandler<CreateHostCommand, Result<Host>>
+{
+    private readonly IRepository<Host> _hostRepository;
+
+    public CreateHostCommandHandler(IRepository<Host> hostRepository)
+    {
+        _hostRepository = hostRepository;
+    }
+
+    public async ValueTask<Result<Host>> Handle(CreateHostCommand request, CancellationToken cancellationToken) =>
+        await Host.TryCreate(request.OwnerId, request.DisplayName)
+            .TapAsync(host => _hostRepository.Add(host, cancellationToken));
+}

--- a/Application/src/Menus/Commands/UpdateMenuCommand.cs
+++ b/Application/src/Menus/Commands/UpdateMenuCommand.cs
@@ -1,0 +1,52 @@
+namespace BuberDinner.Application.Menus.Commands;
+
+using BuberDinner.Domain.Common.ValueObjects;
+using BuberDinner.Domain.Host.Entities;
+using BuberDinner.Domain.Host.ValueObject;
+using BuberDinner.Domain.Menu;
+using BuberDinner.Domain.Menu.ValueObject;
+using Mediator;
+using Trellis.Authorization;
+
+/// <summary>
+/// Updates an existing menu's name and description. Authorization is gated by the owning Host:
+/// the authenticated actor must equal <see cref="Host.OwnerId"/>. The framework wires this via
+/// <see cref="IAuthorizeResource{TResource}"/> + <see cref="IIdentifyResource{TResource, TId}"/>
+/// and the shared <c>SharedResourceLoaderById&lt;Host, HostId&gt;</c> implementation in
+/// <c>Application/Hosts/Authorization/HostResourceLoader.cs</c>.
+///
+/// Optimistic-concurrency control: the controller parses <c>If-Match</c> via
+/// <c>ETagHelper.ParseIfMatch(...)</c> and threads the resulting <see cref="EntityTagValue"/>
+/// array into <see cref="IfMatch"/>. The handler then runs <c>RequireETagAsync(IfMatch)</c>
+/// at the read-modify-write boundary per Cookbook Recipe 23 / RFC 9110 §13.1.1:
+/// missing → 428 Precondition Required; stale → 412 Precondition Failed.
+/// </summary>
+public sealed class UpdateMenuCommand
+    : IRequest<Result<Menu>>, IAuthorizeResource<Host>, IIdentifyResource<Host, HostId>
+{
+    public HostId HostId { get; }
+    public MenuId MenuId { get; }
+    public Name Name { get; }
+    public Description Description { get; }
+    public EntityTagValue[]? IfMatch { get; }
+
+    public static Result<UpdateMenuCommand> TryCreate(
+        HostId hostId, MenuId menuId, Name name, Description description, EntityTagValue[]? ifMatch) =>
+        Result.Ok(new UpdateMenuCommand(hostId, menuId, name, description, ifMatch));
+
+    private UpdateMenuCommand(HostId hostId, MenuId menuId, Name name, Description description, EntityTagValue[]? ifMatch)
+    {
+        HostId = hostId;
+        MenuId = menuId;
+        Name = name;
+        Description = description;
+        IfMatch = ifMatch;
+    }
+
+    public HostId GetResourceId() => HostId;
+
+    public IResult Authorize(Actor actor, Host host) =>
+        host.OwnerId.Value == actor.Id.Value
+            ? Result.Ok()
+            : Result.Fail(new Error.Forbidden("menus.owner", ResourceRef.For<Host>(HostId)));
+}

--- a/Application/src/Menus/Commands/UpdateMenuCommandHandler.cs
+++ b/Application/src/Menus/Commands/UpdateMenuCommandHandler.cs
@@ -1,0 +1,36 @@
+namespace BuberDinner.Application.Menus.Commands;
+
+using System.Threading;
+using System.Threading.Tasks;
+using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.Menu;
+using Mediator;
+
+public sealed class UpdateMenuCommandHandler : IRequestHandler<UpdateMenuCommand, Result<Menu>>
+{
+    private readonly IRepository<Menu> _menuRepository;
+
+    public UpdateMenuCommandHandler(IRepository<Menu> menuRepository)
+    {
+        _menuRepository = menuRepository;
+    }
+
+    public async ValueTask<Result<Menu>> Handle(UpdateMenuCommand request, CancellationToken cancellationToken) =>
+        await LoadMenuAsync(request, cancellationToken)
+            .RequireETagAsync(request.IfMatch)
+            .BindAsync(menu => menu.Update(request.Name, request.Description))
+            .TapAsync(menu => _menuRepository.Update(menu, cancellationToken));
+
+    private async ValueTask<Result<Menu>> LoadMenuAsync(UpdateMenuCommand request, CancellationToken cancellationToken)
+    {
+        var menu = await _menuRepository.FindById(request.MenuId.Value.ToString(), cancellationToken);
+        if (menu is null)
+            return Result.Fail<Menu>(new Error.NotFound(ResourceRef.For<Menu>(request.MenuId)));
+        if (menu.HostId != request.HostId)
+            return Result.Fail<Menu>(new Error.NotFound(ResourceRef.For<Menu>(request.MenuId))
+            {
+                Detail = "Menu does not belong to the specified host.",
+            });
+        return Result.Ok(menu);
+    }
+}

--- a/Application/src/Menus/Queries/GetMenuQuery.cs
+++ b/Application/src/Menus/Queries/GetMenuQuery.cs
@@ -1,0 +1,15 @@
+namespace BuberDinner.Application.Menus.Queries;
+
+using BuberDinner.Domain.Menu;
+using BuberDinner.Domain.Menu.ValueObject;
+using Mediator;
+
+public sealed class GetMenuQuery : IRequest<Result<Menu>>
+{
+    public MenuId MenuId { get; }
+
+    public GetMenuQuery(MenuId menuId)
+    {
+        MenuId = menuId;
+    }
+}

--- a/Application/src/Menus/Queries/GetMenuQuery.cs
+++ b/Application/src/Menus/Queries/GetMenuQuery.cs
@@ -1,15 +1,18 @@
 namespace BuberDinner.Application.Menus.Queries;
 
+using BuberDinner.Domain.Host.ValueObject;
 using BuberDinner.Domain.Menu;
 using BuberDinner.Domain.Menu.ValueObject;
 using Mediator;
 
 public sealed class GetMenuQuery : IRequest<Result<Menu>>
 {
+    public HostId HostId { get; }
     public MenuId MenuId { get; }
 
-    public GetMenuQuery(MenuId menuId)
+    public GetMenuQuery(HostId hostId, MenuId menuId)
     {
+        HostId = hostId;
         MenuId = menuId;
     }
 }

--- a/Application/src/Menus/Queries/GetMenuQueryHandler.cs
+++ b/Application/src/Menus/Queries/GetMenuQueryHandler.cs
@@ -20,6 +20,14 @@ public sealed class GetMenuQueryHandler : IRequestHandler<GetMenuQuery, Result<M
         var menu = await _menuRepository.FindById(request.MenuId.Value.ToString(), cancellationToken);
         if (menu is null)
             return Result.Fail<Menu>(new Error.NotFound(ResourceRef.For<Menu>(request.MenuId)));
+        // Hierarchical-route membership check: same as UpdateMenuCommandHandler. Returning
+        // NotFound (not Forbidden) keeps the response shape symmetric and avoids leaking the
+        // existence of menus the caller has no business asking about.
+        if (menu.HostId != request.HostId)
+            return Result.Fail<Menu>(new Error.NotFound(ResourceRef.For<Menu>(request.MenuId))
+            {
+                Detail = "Menu does not belong to the specified host.",
+            });
         return Result.Ok(menu);
     }
 }

--- a/Application/src/Menus/Queries/GetMenuQueryHandler.cs
+++ b/Application/src/Menus/Queries/GetMenuQueryHandler.cs
@@ -1,0 +1,25 @@
+namespace BuberDinner.Application.Menus.Queries;
+
+using System.Threading;
+using System.Threading.Tasks;
+using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.Menu;
+using Mediator;
+
+public sealed class GetMenuQueryHandler : IRequestHandler<GetMenuQuery, Result<Menu>>
+{
+    private readonly IRepository<Menu> _menuRepository;
+
+    public GetMenuQueryHandler(IRepository<Menu> menuRepository)
+    {
+        _menuRepository = menuRepository;
+    }
+
+    public async ValueTask<Result<Menu>> Handle(GetMenuQuery request, CancellationToken cancellationToken)
+    {
+        var menu = await _menuRepository.FindById(request.MenuId.Value.ToString(), cancellationToken);
+        if (menu is null)
+            return Result.Fail<Menu>(new Error.NotFound(ResourceRef.For<Menu>(request.MenuId)));
+        return Result.Ok(menu);
+    }
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,6 +26,7 @@
     <PackageVersion Include="Trellis.Asp" Version="$(TrellisVersion)" />
     <PackageVersion Include="Trellis.Core" Version="$(TrellisVersion)" />
     <PackageVersion Include="Trellis.FluentValidation" Version="$(TrellisVersion)" />
+    <PackageVersion Include="Trellis.Http.Abstractions" Version="$(TrellisVersion)" />
     <PackageVersion Include="Trellis.Mediator" Version="$(TrellisVersion)" />
     <PackageVersion Include="Trellis.Primitives" Version="$(TrellisVersion)" />
   </ItemGroup>

--- a/Docs/PR1_ETAG_AND_RESOURCE_AUTH.md
+++ b/Docs/PR1_ETAG_AND_RESOURCE_AUTH.md
@@ -1,0 +1,193 @@
+# PR 1 — ETag, Conditional Requests, and Resource-Based Authorization
+
+> *Showcase: how a real BuberDinner endpoint composes the framework's HTTP-precondition
+> machinery, scalar-VO route constraints, and resource-based authorization into a single
+> chain — no per-controller plumbing, no manual `If-Match` parsing, no scattered "is this
+> the owner?" checks.*
+
+---
+
+## What this PR adds (at a glance)
+
+| Capability | Before | After | Cookbook |
+|---|---|---|---|
+| GET a menu | n/a — repository threw `NotImplementedException` | `GET /hosts/{hostId:HostId}/menus/{menuId:MenuId}` returns 200 + strong ETag | Recipe 6 |
+| Conditional GET | n/a | `If-None-Match` → 304 Not Modified | Recipe 6 |
+| Update a menu | n/a | `PUT` with `If-Match` → 200 + bumped ETag | Recipe 23 |
+| Missing precondition | n/a | `PUT` without `If-Match` → 428 Precondition Required | Recipe 23 |
+| Lost-update protection | n/a | `PUT` with stale `If-Match` → 412 Precondition Failed | Recipe 23 |
+| Resource ownership | not checked — any user could mutate any host's menu | `IAuthorizeResource<Host>` → 403 if `Actor.Id != host.OwnerId` | Recipe 7 |
+| Typed route params | string GUID round-trip on every controller | `[Route("hosts/{hostId:HostId}/...")]` — scalar VO bound directly | n/a (Trellis.Asp.Routing) |
+| Host aggregate | did not exist | `Host` aggregate with `OwnerId(UserId)` + `DisplayName(Name)` | n/a |
+
+Everything observed at the wire. Six precondition/auth scenarios are covered by the
+new `MenuEtagAndAuthTests` class + five new `.http` files under `Requests/Hosts` and
+`Requests/Menus`.
+
+## The wire dump (the part you can show in a demo)
+
+```http
+# 1. POST /hosts → 201, OwnerId comes from the JWT `sub` claim.
+HTTP/1.1 201 Created
+Location: /hosts/019e955c-89a3-7f92-a289-35f8823bc135
+
+# 2. GET …/menus/{id} → strong ETag.
+HTTP/1.1 200 OK
+ETag: "e1234e51a87e4710855993de1842d29f"
+
+# 3. GET with matching If-None-Match → 304, no body.
+HTTP/1.1 304 Not Modified
+ETag: "e1234e51a87e4710855993de1842d29f"
+
+# 4. PUT without If-Match → 428, RFC 6585.
+HTTP/1.1 428 Precondition Required
+
+# 5. PUT with stale If-Match → 412, RFC 9110 §15.5.13.
+HTTP/1.1 412 Precondition Failed
+
+# 6. PUT with valid If-Match → 200, ETag bumped.
+HTTP/1.1 200 OK
+ETag: "0ada920e5adc4c7ca9b843350fe5f093"
+
+# 7. PUT by a different user → 403 Forbidden.
+HTTP/1.1 403 Forbidden
+Content-Type: application/problem+json
+{ "status": 403, "code": "menus.owner", "kind": "forbidden", ... }
+```
+
+## How small the controller is
+
+```csharp
+[HttpGet("{menuId:MenuId}")]
+public async ValueTask<ActionResult<MenuResponse>> GetMenu(HostId hostId, MenuId menuId) =>
+    await _sender.Send(new GetMenuQuery(menuId))
+        .ToHttpResponseAsync(
+            body: menu => menu.Adapt<MenuResponse>(),
+            configure: opts => opts
+                .WithETag(menu => EntityTagValue.Strong(menu.ETag))
+                .EvaluatePreconditions())
+        .AsActionResultAsync<MenuResponse>();
+```
+
+That's the entire GET. No `if (Request.Headers.TryGetValue("If-None-Match", …))`,
+no `Response.StatusCode = 304`, no `HttpContext.Response.Headers["ETag"] = …`.
+`WithETag(...).EvaluatePreconditions()` does the precondition algorithm; the body lambda
+only runs if the precondition lets the response through.
+
+The PUT is just as small, with the extra precondition check moved inside the handler
+chain (Recipe 23) so the framework can short-circuit between load and mutate:
+
+```csharp
+[HttpPut("{menuId:MenuId}")]
+public async ValueTask<ActionResult<MenuResponse>> UpdateMenu(
+    HostId hostId, MenuId menuId, [FromBody] UpdateMenuRequest request, CancellationToken ct) =>
+    await request.ToUpdateMenuCommand(hostId, menuId, ETagHelper.ParseIfMatch(HttpContext.Request))
+        .BindAsync(command => _sender.Send(command, ct))
+        .ToHttpResponseAsync(
+            body: menu => menu.Adapt<MenuResponse>(),
+            configure: opts => opts.WithETag(menu => EntityTagValue.Strong(menu.ETag)))
+        .AsActionResultAsync<MenuResponse>();
+```
+
+And the handler chain that drives it:
+
+```csharp
+return await LoadMenuAsync(request, ct)
+    .RequireETagAsync(request.IfMatch)
+    .BindAsync(menu => menu.Update(request.Name, request.Description))
+    .TapAsync(_repo.Update);
+```
+
+Three operators: `RequireETag` (412 if stale, 428 if missing), `Bind` (run the domain
+mutation only if the precondition passed), `Tap` (persist only if the mutation succeeded).
+
+## Resource-based authorization — what we plugged in
+
+The `UpdateMenuCommand` declares its authorization shape directly on the command type:
+
+```csharp
+public sealed record UpdateMenuCommand(...)
+    : ICommand<Result<Menu>>,
+      IAuthorizeResource<Host>,           // gate this command by a Host
+      IIdentifyResource<Host, HostId>     // identify the Host from `command.HostId`
+{
+    public bool IsAuthorized(Host resource, Actor actor) =>
+        resource.OwnerId.Value == actor.Id;
+
+    public string AuthorizationCode => "menus.owner"; // shows up in ProblemDetails.code
+}
+```
+
+The Mediator pipeline (`AddResourceAuthorization`) takes care of:
+1. Loading the `Host` resource (via the `HostResourceLoader` we registered).
+2. Resolving the current `Actor` from the JWT `sub` claim
+   (`AddClaimsActorProvider(opts => opts.ActorIdClaim = "sub")`).
+3. Calling `IsAuthorized` and returning `Error.AuthorizationFailed("menus.owner")` if it returns false.
+4. Translating that error into `403 Forbidden` with `application/problem+json` at the boundary.
+
+If we plug a second `IAuthorizeResource<TParent>` onto the same command, the framework runs them all. There is no controller-level `[Authorize(Policy = ...)]` to maintain and no per-handler "did I forget the ownership check?" risk.
+
+## Scalar VO route constraints — the un-glamorous big win
+
+Before this PR, every controller signature took `string hostId, string menuId` and
+the first line of every action was a `Guid.TryParse` or `HostId.TryCreate`. We were
+paying for the route binding twice: once when ASP.NET parsed the URL, again when we
+hand-converted the string to a typed value.
+
+```csharp
+// before
+public async Task<ActionResult> CreateMenu(CreateMenuRequest request, string hostId) =>
+    await request.ToCreateMenuCommand(hostId)   // does TryParse internally
+        .BindAsync(...)
+        ...
+
+// after
+public async Task<ActionResult> CreateMenu(CreateMenuRequest request, HostId hostId) =>
+    await request.ToCreateMenuCommand(hostId.Value.ToString())  // already typed
+        .BindAsync(...)
+        ...
+```
+
+Registered with two lines in `Api/src/DependencyInjection.cs`:
+
+```csharp
+services.AddTrellisRouteConstraint<HostId>(nameof(HostId));
+services.AddTrellisRouteConstraint<MenuId>(nameof(MenuId));
+```
+
+And consumed in the route template:
+
+```csharp
+[Route("hosts/{hostId:HostId}/menus/{menuId:MenuId}")]
+```
+
+If the URL contains a non-GUID, ASP.NET returns 404 *before* the action ever runs — no
+hand-rolled validator, no Result threading for parse failures. (One pre-existing test
+needed a tweak because `Guid.ToString()` normalises to lowercase; we now compare GUIDs
+case-insensitively in the Location-header assertion, per RFC 4122 §3.)
+
+## Annoyance worth filing back (reg-005)
+
+`Aggregate<TId>.ETag` has an `internal` setter. The intended consumer is
+`Trellis.EntityFrameworkCore`, which sets the property after a successful round-trip to
+the database. We're using an in-memory repository here (just like the EF integration tests
+do) so we need to mimic that hand-off — and the only path open to us is reflection. The
+workaround lives in `Infrastructure/src/Persistence/Memory/AggregateETagWriter.cs`:
+walks the runtime type hierarchy looking for `ETag` (declared on the concrete aggregate
+or any base type) and falls back to the `<ETag>k__BackingField` compiler-generated field.
+Caches the writer per type in a `ConcurrentDictionary` so the reflection cost is paid once.
+
+This file should go away the moment the framework exposes a `protected void
+SetETag(string)` hook, or accepts the ETag in `Aggregate<TId>`'s constructor. We've left
+a `// TODO(framework reg-005)` marker in the file.
+
+## Files that show off the most
+
+| File | Why look here |
+|---|---|
+| `Api/src/2022-12-21/Controllers/MenusController.cs` | 30 lines of handler glue for GET+PUT, including the precondition algorithm and ETag emission |
+| `Application/src/Menus/Commands/UpdateMenuCommand.cs` | `IAuthorizeResource<Host>` + `IIdentifyResource<Host, HostId>` declared on the command itself |
+| `Application/src/Menus/Commands/UpdateMenuCommandHandler.cs` | Three-operator chain: load → `RequireETag` → mutate → persist |
+| `Api/src/DependencyInjection.cs` | All wiring for route constraints, claims actor provider, resource auth in <10 lines |
+| `Api/tests/2022-12-21/MenuEtagAndAuthTests.cs` | Six precondition / auth scenarios at the wire |
+| `Requests/Menus/UpdateMenu-IfMatchMismatch.http` | All three PUT failure modes side-by-side |

--- a/Domain/src/Host/Entities/Host.cs
+++ b/Domain/src/Host/Entities/Host.cs
@@ -1,0 +1,39 @@
+namespace BuberDinner.Domain.Host.Entities;
+
+using BuberDinner.Domain.Common.ValueObjects;
+using BuberDinner.Domain.Host.ValueObject;
+using BuberDinner.Domain.User.ValueObjects;
+using FluentValidation;
+
+/// <summary>
+/// A Host owns Menus and (later) Dinners. Resource-based authorization on Menu mutations
+/// is gated by the Host's <see cref="OwnerId"/> matching the calling actor's id.
+/// </summary>
+public class Host : Aggregate<HostId>
+{
+    public UserId OwnerId { get; }
+    public Name DisplayName { get; }
+
+    public static Result<Host> TryCreate(UserId ownerId, Name displayName) =>
+        TryCreate(HostId.NewUniqueV7(), ownerId, displayName);
+
+    public static Result<Host> TryCreate(HostId id, UserId ownerId, Name displayName)
+    {
+        Host host = new(id, ownerId, displayName);
+        return s_validator.ValidateToResult(host);
+    }
+
+    private Host(HostId id, UserId ownerId, Name displayName)
+        : base(id)
+    {
+        OwnerId = ownerId;
+        DisplayName = displayName;
+    }
+
+    static readonly InlineValidator<Host> s_validator = new()
+    {
+        v => v.RuleFor(x => x.Id).NotEmpty(),
+        v => v.RuleFor(x => x.OwnerId).NotNull(),
+        v => v.RuleFor(x => x.DisplayName).NotNull(),
+    };
+}

--- a/Domain/src/Menu/Menu.cs
+++ b/Domain/src/Menu/Menu.cs
@@ -10,8 +10,8 @@ using FluentValidation;
 
 public class Menu : Aggregate<MenuId>
 {
-    public Name Name { get; }
-    public Description Description { get; }
+    public Name Name { get; private set; }
+    public Description Description { get; private set; }
     public decimal? AverageRating { get; }
     public IReadOnlyList<MenuSection> Sections => _menuSections.AsReadOnly();
     public HostId HostId { get; }
@@ -78,6 +78,18 @@ public class Menu : Aggregate<MenuId>
         Description = description;
         AverageRating = averageRating;
         HostId = hostId;
+    }
+
+    /// <summary>
+    /// Updates the menu's name and description. Returns a validated <see cref="Result{Menu}"/>
+    /// so callers can compose on the Result track. Caller is responsible for the persistence
+    /// commit (which bumps the optimistic-concurrency ETag) — see Recipe 23 in the cookbook.
+    /// </summary>
+    public Result<Menu> Update(Name name, Description description)
+    {
+        Name = name;
+        Description = description;
+        return s_validator.ValidateToResult(this);
     }
 
     static readonly InlineValidator<Menu> s_validator = new()

--- a/Domain/src/Menu/Menu.cs
+++ b/Domain/src/Menu/Menu.cs
@@ -82,14 +82,25 @@ public class Menu : Aggregate<MenuId>
 
     /// <summary>
     /// Updates the menu's name and description. Returns a validated <see cref="Result{Menu}"/>
-    /// so callers can compose on the Result track. Caller is responsible for the persistence
-    /// commit (which bumps the optimistic-concurrency ETag) — see Recipe 23 in the cookbook.
+    /// so callers can compose on the Result track. Mutation is applied speculatively and rolled
+    /// back if aggregate-invariant validation fails — important because in-memory repositories
+    /// hand out live aggregate references, so a half-applied mutation would otherwise leak into
+    /// subsequent reads. Caller is responsible for the persistence commit (which bumps the
+    /// optimistic-concurrency ETag) — see Recipe 23 in the cookbook.
     /// </summary>
     public Result<Menu> Update(Name name, Description description)
     {
+        var previousName = Name;
+        var previousDescription = Description;
         Name = name;
         Description = description;
-        return s_validator.ValidateToResult(this);
+        var result = s_validator.ValidateToResult(this);
+        if (result.IsFailure)
+        {
+            Name = previousName;
+            Description = previousDescription;
+        }
+        return result;
     }
 
     static readonly InlineValidator<Menu> s_validator = new()

--- a/Infrastructure/src/DependencyInjection.cs
+++ b/Infrastructure/src/DependencyInjection.cs
@@ -6,6 +6,7 @@ using BuberDinner.Application.Abstractions.Authentication;
 using BuberDinner.Application.Abstractions.Persistence;
 using BuberDinner.Domain.Menu;
 using BuberDinner.Domain.User.Entities;
+using HostEntity = BuberDinner.Domain.Host.Entities.Host;
 using BuberDinner.Infrastructure.Authentication;
 using BuberDinner.Infrastructure.Persistence.Cosmos;
 using BuberDinner.Infrastructure.Persistence.Memory;
@@ -67,6 +68,7 @@ public static class DependencyInjection
     {
         services.AddScoped<IRepository<User>, UserInMemoryRepository>();
         services.AddScoped<IRepository<Menu>, MenuInMemoryRepository>();
+        services.AddScoped<IRepository<HostEntity>, HostInMemoryRepository>();
         return services;
     }
 }

--- a/Infrastructure/src/DependencyInjection.cs
+++ b/Infrastructure/src/DependencyInjection.cs
@@ -61,6 +61,11 @@ public static class DependencyInjection
         services.AddSingleton(CosmosClientFactory.InitializeCosmosClientInstance(cosmosDbClientSettings));
         services.AddScoped<IRepository<User>, UserCosmosDbRepository>();
         services.AddScoped<IRepository<Menu>, MenuCosmosDbRepository>();
+        // TODO: replace with HostCosmosDbRepository when implemented. Until then, fall back to
+        // the in-memory implementation so a Cosmos-configured deploy doesn't crash on the first
+        // POST /hosts or PUT /hosts/.../menus/... (which loads the parent Host for
+        // IAuthorizeResource<Host>). Tracked alongside the broader 5-PR showcase roadmap.
+        services.AddScoped<IRepository<HostEntity>, HostInMemoryRepository>();
         return services;
     }
 

--- a/Infrastructure/src/Persistence/Memory/AggregateETagWriter.cs
+++ b/Infrastructure/src/Persistence/Memory/AggregateETagWriter.cs
@@ -1,0 +1,75 @@
+namespace BuberDinner.Infrastructure.Persistence.Memory;
+
+using System.Collections.Concurrent;
+using System.Reflection;
+
+/// <summary>
+/// Sets the framework-internal <c>Aggregate&lt;TId&gt;.ETag</c> property via reflection.
+///
+/// Trellis V3 documents <c>ETag</c> as "Persistence-managed". The setter lives on the
+/// concrete <c>Aggregate&lt;TId&gt;</c> base class (not on the <c>IAggregate</c>
+/// interface) and is <c>internal</c> — only Trellis-internal persistence assemblies
+/// (Trellis.EntityFrameworkCore in the box) can write it through normal C#. Consumers
+/// using non-EF backends (in-memory, custom JSON store, Cosmos via Microsoft.Azure.Cosmos
+/// directly, etc.) have no public hook for writing the ETag, so the framework helpers
+/// <c>AggregateETagExtensions.OptionalETag</c> / <c>RequireETag</c> can never see the
+/// repository's persisted ETag value.
+///
+/// This helper bridges the gap by reflecting against the concrete aggregate's
+/// runtime type (which has the setter, even if internal) — or falling back to the
+/// compiler-generated backing field <c>&lt;ETag&gt;k__BackingField</c> when the
+/// property has no exposed setter at all.
+///
+/// Local to BuberDinner's in-memory persistence layer; not exposed beyond the Memory
+/// namespace. When the framework ships a public infrastructure hook, delete this file.
+///
+/// Tracked as framework feedback: in-memory / custom-persistence ETag write-hook gap
+/// (reg-005-aggregate-etag-write-hook).
+/// </summary>
+internal static class AggregateETagWriter
+{
+    private static readonly ConcurrentDictionary<Type, Action<object, string>> s_setters = new();
+
+    public static void SetETag<TAggregate>(TAggregate aggregate, string etag)
+        where TAggregate : global::Trellis.IAggregate
+    {
+        ArgumentNullException.ThrowIfNull(aggregate);
+        ArgumentNullException.ThrowIfNull(etag);
+        var setter = s_setters.GetOrAdd(aggregate.GetType(), BuildSetter);
+        setter(aggregate, etag);
+    }
+
+    private static Action<object, string> BuildSetter(Type aggregateType)
+    {
+        // Walk up the hierarchy looking for an ETag property with a settable backer.
+        for (var t = aggregateType; t is not null; t = t.BaseType)
+        {
+            var prop = t.GetProperty("ETag",
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+            if (prop is not null)
+            {
+                var setMethod = prop.GetSetMethod(nonPublic: true);
+                if (setMethod is not null)
+                    return (obj, val) => setMethod.Invoke(obj, new object[] { val });
+
+                // Property has no setter at all (init-only or get-only auto-prop).
+                // Fall through to the backing field below.
+                break;
+            }
+        }
+
+        // Fallback: the compiler-generated backing field for `ETag`.
+        for (var t = aggregateType; t is not null; t = t.BaseType)
+        {
+            var field = t.GetField("<ETag>k__BackingField",
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+            if (field is not null)
+                return (obj, val) => field.SetValue(obj, val);
+        }
+
+        throw new InvalidOperationException(
+            $"Cannot find a way to set Aggregate<TId>.ETag on type {aggregateType.FullName}. " +
+            "The framework's ETag setter shape may have changed; revisit AggregateETagWriter.");
+    }
+}
+

--- a/Infrastructure/src/Persistence/Memory/HostInMemoryRepository.cs
+++ b/Infrastructure/src/Persistence/Memory/HostInMemoryRepository.cs
@@ -1,0 +1,52 @@
+namespace BuberDinner.Infrastructure.Persistence.Memory;
+
+using System.Collections.Generic;
+using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.Host.Entities;
+
+internal class HostInMemoryRepository : IRepository<Host>
+{
+    private static readonly List<Host> s_hosts = new();
+    private static readonly object s_lock = new();
+
+    public IEnumerable<Host> GetAll(CancellationToken cancellationToken)
+    {
+        lock (s_lock)
+            return s_hosts.ToList();
+    }
+
+    public ValueTask Add(Host host, CancellationToken cancellationToken)
+    {
+        lock (s_lock)
+            s_hosts.Add(host);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask Update(Host host, CancellationToken cancellationToken)
+    {
+        lock (s_lock)
+        {
+            int index = s_hosts.FindIndex(h => h.Id == host.Id);
+            if (index < 0)
+                s_hosts.Add(host);
+            else
+                s_hosts[index] = host;
+        }
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask Delete(Host host, CancellationToken cancellationToken)
+    {
+        lock (s_lock)
+            s_hosts.RemoveAll(h => h.Id == host.Id);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<Host?> FindById(string id, CancellationToken cancellationToken)
+    {
+        Host? host;
+        lock (s_lock)
+            host = s_hosts.SingleOrDefault(h => h.Id.Value.ToString() == id);
+        return ValueTask.FromResult(host);
+    }
+}

--- a/Infrastructure/src/Persistence/Memory/MenuInMemoryRepository.cs
+++ b/Infrastructure/src/Persistence/Memory/MenuInMemoryRepository.cs
@@ -1,5 +1,6 @@
-﻿namespace BuberDinner.Infrastructure.Persistence.Memory;
+namespace BuberDinner.Infrastructure.Persistence.Memory;
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using BuberDinner.Application.Abstractions.Persistence;
 using BuberDinner.Domain.Menu;
@@ -7,26 +8,66 @@ using BuberDinner.Domain.Menu;
 internal class MenuInMemoryRepository : IRepository<Menu>
 {
     private static readonly List<Menu> s_menus = new();
+    // Parallel ETag store: in a real persistence layer the ETag is the row-version that the
+    // database emits on write. The in-memory equivalent is just a monotonic GUID per save —
+    // good enough to demonstrate If-Match concurrency control end-to-end.
+    private static readonly ConcurrentDictionary<string, string> s_etags = new(StringComparer.Ordinal);
+    private static readonly object s_lock = new();
+
     public IEnumerable<Menu> GetAll(CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        lock (s_lock)
+            return s_menus.ToList();
     }
 
     public ValueTask Add(Menu menu, CancellationToken cancellationToken)
     {
-        s_menus.Add(menu);
+        lock (s_lock)
+        {
+            s_menus.Add(menu);
+            BumpETag(menu);
+        }
         return ValueTask.CompletedTask;
     }
+
     public ValueTask Update(Menu menu, CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        lock (s_lock)
+        {
+            int index = s_menus.FindIndex(m => m.Id == menu.Id);
+            if (index < 0)
+                s_menus.Add(menu);
+            else
+                s_menus[index] = menu;
+            BumpETag(menu);
+        }
+        return ValueTask.CompletedTask;
     }
 
     public ValueTask Delete(Menu menu, CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        lock (s_lock)
+        {
+            s_menus.RemoveAll(m => m.Id == menu.Id);
+            s_etags.TryRemove(menu.Id.Value.ToString(), out _);
+        }
+        return ValueTask.CompletedTask;
     }
 
-    public ValueTask<Menu?> FindById(string id, CancellationToken cancellationToken) =>
-        throw new NotImplementedException();
+    public ValueTask<Menu?> FindById(string id, CancellationToken cancellationToken)
+    {
+        Menu? menu;
+        lock (s_lock)
+            menu = s_menus.SingleOrDefault(m => m.Id.Value.ToString() == id);
+        if (menu is not null && s_etags.TryGetValue(id, out var etag))
+            AggregateETagWriter.SetETag(menu, etag);
+        return ValueTask.FromResult(menu);
+    }
+
+    private static void BumpETag(Menu menu)
+    {
+        var newETag = Guid.NewGuid().ToString("N");
+        s_etags[menu.Id.Value.ToString()] = newETag;
+        AggregateETagWriter.SetETag(menu, newETag);
+    }
 }

--- a/Requests/Hosts/CreateHost.http
+++ b/Requests/Hosts/CreateHost.http
@@ -1,0 +1,26 @@
+### Create a Host owned by the authenticated user.
+### Requires a Bearer token from Authentication/Register.http or Authentication/Login.http.
+### The Host's OwnerId is taken from the JWT `sub` claim (see Api.DependencyInjection
+### `AddClaimsActorProvider(opts => opts.ActorIdClaim = "sub")`). All subsequent
+### CreateMenu/UpdateMenu calls under `/hosts/{hostId}/menus/...` will be gated by
+### `IAuthorizeResource<Host>` (Cookbook Recipe 7): a user can only mutate menus
+### attached to a Host they own.
+
+@token = yourtoken
+
+POST {{host}}/hosts?api-version=2022-10-01
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "displayName": "Xavier's Kitchen"
+}
+
+### Expected response shape:
+### HTTP/1.1 201 Created
+### Location: /hosts/{hostId}
+### {
+###   "id": "019e955c-89a3-7f92-a289-35f8823bc135",
+###   "displayName": "Xavier's Kitchen",
+###   "ownerId": "xavierjohn2023"
+### }

--- a/Requests/Menus/GetMenu-NotModified.http
+++ b/Requests/Menus/GetMenu-NotModified.http
@@ -1,0 +1,20 @@
+### Conditional GET that returns 304 Not Modified when the client's cached ETag
+### matches the server's current ETag. Demonstrates RFC 9110 §13.1.2 (If-None-Match).
+### Paste the ETag returned by Menus/GetMenu.http into the If-None-Match header below.
+
+@token = yourtoken
+@hostId = 019E955C-89A3-7F92-A289-35F8823BC135
+@menuId = 019E955C-8A14-7B4C-8B40-F82FFB3B05F1
+@etag = "0ada920e5adc4c7ca9b843350fe5f093"
+
+GET {{host}}/hosts/{{hostId}}/menus/{{menuId}}?api-version=2022-10-01
+Authorization: Bearer {{token}}
+If-None-Match: {{etag}}
+
+### Expected response shape:
+### HTTP/1.1 304 Not Modified
+### ETag: "0ada920e5adc4c7ca9b843350fe5f093"
+### (no body)
+###
+### If a different (stale) ETag is sent, the server treats the precondition as
+### unmatched and returns the full 200 + body.

--- a/Requests/Menus/GetMenu.http
+++ b/Requests/Menus/GetMenu.http
@@ -1,0 +1,27 @@
+### Get a menu by id (happy path). Emits a strong ETag for conditional requests.
+### Requires a Bearer token AND a {{hostId}}/{{menuId}} from CreateMenu.http
+### (use the `id` in the response body for {{menuId}} and the `hostId` you created
+### in Hosts/CreateHost.http).
+### Per Cookbook Recipe 6 — `WithETag(...).EvaluatePreconditions()`.
+
+@token = yourtoken
+@hostId = 019E955C-89A3-7F92-A289-35F8823BC135
+@menuId = 019E955C-8A14-7B4C-8B40-F82FFB3B05F1
+
+GET {{host}}/hosts/{{hostId}}/menus/{{menuId}}?api-version=2022-10-01
+Authorization: Bearer {{token}}
+
+### Expected response shape:
+### HTTP/1.1 200 OK
+### ETag: "0ada920e5adc4c7ca9b843350fe5f093"
+### Content-Type: application/json
+### {
+###   "id":"019e955c-8a14-7b4c-8b40-f82ffb3b05f1",
+###   "name":"Brunch",
+###   "description":"Sunday brunch menu",
+###   "averageRating":null,
+###   "sections":[ ... ],
+###   "hostId":"019e955c-89a3-7f92-a289-35f8823bc135",
+###   "dinnerIds":[],
+###   "menuReviewIds":[]
+### }

--- a/Requests/Menus/UpdateMenu-IfMatchMismatch.http
+++ b/Requests/Menus/UpdateMenu-IfMatchMismatch.http
@@ -1,0 +1,74 @@
+### Showcases the three failure modes for PUT /hosts/{hostId}/menus/{menuId}:
+###   1. Missing If-Match     → 428 Precondition Required (RFC 6585 §3)
+###   2. Stale  If-Match      → 412 Precondition Failed   (RFC 9110 §15.5.13)
+###   3. Cross-owner request  → 403 Forbidden             (Resource-based auth, Recipe 7)
+###
+### Send each in sequence; none of them should ever mutate state.
+
+@token = yourtoken
+@otherToken = yourothertoken
+@hostId = 019E955C-89A3-7F92-A289-35F8823BC135
+@menuId = 019E955C-8A14-7B4C-8B40-F82FFB3B05F1
+
+### 1. PUT WITHOUT If-Match — expect 428 Precondition Required.
+###    The framework's `EvaluatePreconditions()` + `RequireETagAsync` combo enforces
+###    that every PUT carries an explicit revision token. Prevents lost updates.
+
+PUT {{host}}/hosts/{{hostId}}/menus/{{menuId}}?api-version=2022-10-01
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "name": "Updated Name",
+    "description": "Updated description"
+}
+
+### Expected response:
+### HTTP/1.1 428 Precondition Required
+### Content-Type: application/problem+json
+
+
+### 2. PUT with a STALE If-Match — expect 412 Precondition Failed.
+###    The handler chain (load → RequireETagAsync → mutate) short-circuits before
+###    the mutation runs, so the existing menu is unchanged.
+
+PUT {{host}}/hosts/{{hostId}}/menus/{{menuId}}?api-version=2022-10-01
+Authorization: Bearer {{token}}
+If-Match: "deadbeefdeadbeefdeadbeefdeadbeef"
+Content-Type: application/json
+
+{
+    "name": "Updated Name",
+    "description": "Updated description"
+}
+
+### Expected response:
+### HTTP/1.1 412 Precondition Failed
+### Content-Type: application/problem+json
+
+
+### 3. PUT as a different user (with a valid token but no ownership of the Host) —
+###    expect 403 Forbidden. The check happens via `IAuthorizeResource<Host>` on
+###    `UpdateMenuCommand`, which compares the Host's `OwnerId` to the Trellis
+###    `Actor.Id` produced from the JWT `sub` claim.
+
+PUT {{host}}/hosts/{{hostId}}/menus/{{menuId}}?api-version=2022-10-01
+Authorization: Bearer {{otherToken}}
+If-Match: "0ada920e5adc4c7ca9b843350fe5f093"
+Content-Type: application/json
+
+{
+    "name": "Pwned",
+    "description": "By a different user"
+}
+
+### Expected response:
+### HTTP/1.1 403 Forbidden
+### Content-Type: application/problem+json
+### {
+###   "type":"https://tools.ietf.org/html/rfc9110#section-15.5.4",
+###   "title":"Forbidden",
+###   "status":403,
+###   "code":"menus.owner",
+###   "kind":"forbidden"
+### }

--- a/Requests/Menus/UpdateMenu.http
+++ b/Requests/Menus/UpdateMenu.http
@@ -1,0 +1,37 @@
+### Update a menu with full optimistic concurrency (RFC 9110 §13.1.1 + RFC 6585).
+### Requires an `If-Match` header with the current ETag (obtain via Menus/GetMenu.http).
+### The handler chain (Cookbook Recipe 23) loads the menu, checks ETag, then mutates —
+### so a stale client never overwrites a newer revision.
+
+@token = yourtoken
+@hostId = 019E955C-89A3-7F92-A289-35F8823BC135
+@menuId = 019E955C-8A14-7B4C-8B40-F82FFB3B05F1
+@etag = "0ada920e5adc4c7ca9b843350fe5f093"
+
+PUT {{host}}/hosts/{{hostId}}/menus/{{menuId}}?api-version=2022-10-01
+Authorization: Bearer {{token}}
+If-Match: {{etag}}
+Content-Type: application/json
+
+{
+    "name": "Brunch v2",
+    "description": "Updated brunch menu"
+}
+
+### Expected response shape:
+### HTTP/1.1 200 OK
+### ETag: "<new-etag-here>"
+### Content-Type: application/json
+### {
+###   "id":"019e955c-8a14-7b4c-8b40-f82ffb3b05f1",
+###   "name":"Brunch v2",
+###   "description":"Updated brunch menu",
+###   ...
+### }
+###
+### Related failure modes (see UpdateMenu-IfMatchMismatch.http for the wire dumps):
+###  - PUT with no  If-Match → 428 Precondition Required
+###  - PUT with bad If-Match → 412 Precondition Failed
+###  - PUT as a user who doesn't own the parent Host → 403 Forbidden
+###    (code: "menus.owner" — set by Application/Menus/Commands/UpdateMenuCommand.cs
+###     `IAuthorizeResource<Host>.OwnerId == actor.Id` check)


### PR DESCRIPTION
# PR 1 — ETag + conditional requests + resource-based authorization

> *Companion PR to #26: builds out four of the six "Tier 1 / Tier 2 follow-ups"
> identified after the Trellis V3 migration landed on `main`.*

## TL;DR

| What | Where | Cookbook recipe |
|---|---|---|
| `GET /hosts/{hostId:HostId}/menus/{menuId:MenuId}` returns 200 + strong ETag | `MenusController.GetMenu` | 6 |
| `If-None-Match` → 304 (conditional GET) | same — handled by `opts.WithETag(...).EvaluatePreconditions()` | 6 |
| `PUT` with `If-Match` for optimistic concurrency: 200, 412, 428 | `MenusController.UpdateMenu` + handler chain | 23 |
| Resource-based authorization: cross-owner `PUT` → 403 | `UpdateMenuCommand : IAuthorizeResource<Host>` | 7 |
| Scalar-VO route constraints | `[Route("hosts/{hostId:HostId}/...")]`, `AddTrellisRouteConstraint<HostId>+<MenuId>` | n/a |
| `Host` aggregate (owner-of-menus) | new — `Domain/src/Host/Entities/Host.cs` | n/a |

## Six wire scenarios verified end-to-end

All six are covered by `Api/tests/2022-12-21/MenuEtagAndAuthTests.cs` and by the new `.http` files under `Requests/Hosts/` and `Requests/Menus/`.

```http
# 1. POST /hosts → 201, OwnerId comes from JWT `sub`.
HTTP/1.1 201 Created
Location: /hosts/019e955c-89a3-7f92-a289-35f8823bc135

# 2. GET menu → strong ETag.
HTTP/1.1 200 OK
ETag: "e1234e51a87e4710855993de1842d29f"

# 3. GET with matching If-None-Match → 304.
HTTP/1.1 304 Not Modified

# 4. PUT without If-Match → 428 (RFC 6585).
HTTP/1.1 428 Precondition Required

# 5. PUT with stale If-Match → 412 (RFC 9110 §15.5.13).
HTTP/1.1 412 Precondition Failed

# 6. PUT with valid If-Match → 200 + bumped ETag.
HTTP/1.1 200 OK
ETag: "0ada920e5adc4c7ca9b843350fe5f093"

# 7. PUT by a different user → 403 with code "menus.owner".
HTTP/1.1 403 Forbidden
Content-Type: application/problem+json
{ "status":403, "code":"menus.owner", "kind":"forbidden", ... }
```

## Commit walkthrough (6 commits)

| # | sha | Scope |
|---|---|---|
| 1 | `1a07e07` | `feat(domain)`: Host aggregate + `Menu.Update(Name, Description)` |
| 2 | `e37bd22` | `feat(infra)`: in-memory ETag tracking + `HostInMemoryRepository` |
| 3 | `cca8a1b` | `feat(app)`: `CreateHostCommand` + `GetMenuQuery` + `UpdateMenuCommand` with `IAuthorizeResource<Host>` |
| 4 | `1654fcf` | `feat(api)`: `HostsController`, `MenusController` GET/PUT, route constraints, claims actor, resource auth wiring |
| 5 | `db38b9f` | `test(api)`: 7 new integration tests covering all 6 wire scenarios |
| 6 | `65952d9` | `docs`: `Docs/PR1_ETAG_AND_RESOURCE_AUTH.md` + 5 `.http` files |

## Build + test

```
0 Warning(s)  /  0 Error(s)
Domain tests:        19/19  ✓
Application tests:    1/1   ✓
Api tests:           35/35  ✓  (+7 new, +1 fixed pre-existing assertion)
Infrastructure:       0/2   (live-Cosmos — pre-existing baseline)
```

The pre-existing assertion fixed in commit 5: `MenusControllerTests.Create_menu` compared the Location header GUID case-sensitively (`/hosts/4F82063C-...`). The new `:HostId` route constraint parses the GUID into a typed value and `Guid.ToString()` lowercases it — case-insensitive comparison per RFC 4122 §3 is the correct fix.

## New framework regression filed (reg-005, low priority)

`Aggregate<TId>.ETag` has an `internal` setter — only `Trellis.EntityFrameworkCore` can write it. The in-memory repository workaround lives in `Infrastructure/src/Persistence/Memory/AggregateETagWriter.cs` (reflection: walks the runtime type hierarchy, falls back to the compiler-generated backing field). It's marked `// TODO(framework reg-005)` and should be deleted once the framework exposes a `protected SetETag(string)` hook or accepts ETag in the constructor.

## What's NOT in this PR (deferred)

- `Trellis.Testing` assertion helpers (Tier 1 #4)
- `AddTrellisFluentValidation` at the command boundary (Tier 2 #6)
- `[Idempotent]` on POST endpoints (Tier 3 #7)
- Domain events on Menu/User aggregates (Tier 3 #9)

These follow in PRs 2–5 of the broader showcase build-out.
