### PR TITLE
feat: Dinner aggregate with Stateless state machine + per-transition domain events

### DIFF
--- a/.github/trellis-api-statemachine.md
+++ b/.github/trellis-api-statemachine.md
@@ -1,0 +1,178 @@
+﻿---
+package: Trellis.StateMachine
+namespaces: [Trellis.StateMachine]
+types: [StateMachineExtensions, "LazyStateMachine<TState, TTrigger>"]
+version: v3
+last_verified: 2026-06-03
+audience: [llm]
+---
+# Trellis.StateMachine — API Reference
+
+## Header
+
+- **Package:** `Trellis.StateMachine`
+- **Namespace:** `Trellis.StateMachine`
+- **Purpose:** Wraps Stateless state transitions in Trellis `Result<TState>` APIs and provides lazy state-machine construction for aggregate materialization scenarios.
+
+See also: [trellis-api-cookbook.md](trellis-api-cookbook.md#recipe-9--state-machine-canfire--fire-pattern-with-fireresult) — recipes using this package.
+
+## Use this file when
+
+- You are wrapping Stateless transitions in Trellis `Result<TState>` values.
+- You need lazy state-machine construction for aggregates materialized by an ORM.
+- You need the exact invalid-transition behavior of `FireResult`.
+
+## Patterns Index
+
+| Goal | Canonical API / pattern | See |
+|---|---|---|
+| Fire a Stateless trigger and get a Trellis result | `stateMachine.FireResult(trigger)` | [`StateMachineExtensions`](#statemachineextensions) |
+| Store a state machine inside an aggregate | `LazyStateMachine<TState,TTrigger>` with state accessor/mutator delegates | [`LazyStateMachine<TState, TTrigger>`](#lazystatemachinetstate-ttrigger) |
+| Treat invalid transitions as validation failures | Let `FireResult` short-circuit when `CanFire` returns `false` and return `Error.InvalidInput` | [Behavioral notes](#behavioral-notes) |
+| Apply business mutations after successful transition | Call `.FireResult(...)`, then mutate/domain-event in a `.Tap(...)` or explicit success branch | [Code examples](#code-examples), [Cookbook Recipe 9](trellis-api-cookbook.md#recipe-9--state-machine-canfire--fire-pattern-with-fireresult) |
+
+## Common traps
+
+- Do not model triggers as raw strings when the domain already has a typed enum/value object.
+- Do not put business side effects in Stateless configuration unless they are purely transition mechanics. Keep domain mutation and events after `FireResult` succeeds.
+- `FireResult` does not make Stateless thread-safe; external synchronization is still required for concurrent use.
+
+## Types
+
+### `StateMachineExtensions`
+
+**Declaration**
+
+```csharp
+public static class StateMachineExtensions
+```
+
+**Constructors**
+
+- None. This is a static class.
+
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| None | — | This static class exposes no public properties. |
+
+**Methods**
+
+| Signature | Returns | Description |
+| --- | --- | --- |
+| `public static Result<TState> FireResult<TState, TTrigger>(this StateMachine<TState, TTrigger> stateMachine, TTrigger trigger) where TState : notnull where TTrigger : notnull` | `Result<TState>` | Pre-checks with `stateMachine.CanFire(trigger)` (which honors `PermitIf`/`IgnoreIf` guards). When permitted, calls `stateMachine.Fire(trigger)` and returns `Result.Ok(stateMachine.State)`. When not permitted, returns `Error.InvalidInput.ForRule("state.machine.invalid.transition", $"Trigger '{trigger}' is not permitted from state '{stateMachine.State}'.")` (HTTP 422) without invoking `Fire(trigger)`, so user-configured `OnUnhandledTrigger` callbacks do not run through `FireResult`. Consumers who need those callbacks must call Stateless `Fire` directly. `InvalidOperationException` thrown while evaluating a guard is translated to `Error.InvalidInput` with the exception message; other exception types and exceptions from user entry/exit/transition actions propagate untouched. Independent of Stateless's exception message format. |
+
+### `LazyStateMachine<TState, TTrigger>`
+
+**Declaration**
+
+```csharp
+public sealed class LazyStateMachine<TState, TTrigger>
+    where TState : notnull
+    where TTrigger : notnull
+```
+
+**Constructors**
+
+- `public LazyStateMachine(Func<TState> stateAccessor, Action<TState> stateMutator, Action<StateMachine<TState, TTrigger>> configure)`  
+  Throws `ArgumentNullException` when `stateAccessor`, `stateMutator`, or `configure` is `null`. The constructor stores the delegates only; it does not invoke `stateAccessor`, `stateMutator`, or `configure`.
+
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `Machine` | `StateMachine<TState, TTrigger>` | Returns `_machine ??= CreateMachine()`. First access constructs `new StateMachine<TState, TTrigger>(_stateAccessor, _stateMutator)`, invokes `_configure(machine)`, caches the instance, and returns it. |
+
+**Methods**
+
+| Signature | Returns | Description |
+| --- | --- | --- |
+| `public Result<TState> FireResult(TTrigger trigger)` | `Result<TState>` | Delegates to `Machine.FireResult(trigger)`. On first use, this also triggers lazy creation and configuration of the underlying `StateMachine<TState, TTrigger>`. |
+
+## Extension methods
+
+### `StateMachineExtensions`
+
+```csharp
+public static Result<TState> FireResult<TState, TTrigger>(
+    this StateMachine<TState, TTrigger> stateMachine,
+    TTrigger trigger)
+    where TState : notnull
+    where TTrigger : notnull
+```
+
+## Behavioral notes
+
+- `StateMachineExtensions.FireResult` does **not** make Stateless thread-safe. Concurrent use of the same `StateMachine<TState, TTrigger>` instance still requires external synchronization. Because Stateless is single-threaded by contract, the `CanFire`+`Fire` pre-check pattern is race-free when used as documented.
+- `StateMachineExtensions.FireResult` null-checks `stateMachine` and throws `ArgumentNullException` for a `null` receiver before any Trellis error conversion occurs.
+- `LazyStateMachine<TState, TTrigger>` is also **not** thread-safe. Its lazy initialization uses `_machine ??= CreateMachine()` with no locking.
+- Invalid-transition detection uses `StateMachine.CanFire(trigger)` (which honors `PermitIf`/`IgnoreIf` guards) — no message-string parsing, so it is resilient to Stateless library upgrades.
+- When `CanFire` returns `false`, `FireResult` returns `Error.InvalidInput.ForRule("state.machine.invalid.transition", $"Trigger '{trigger}' is not permitted from state '{stateMachine.State}'.")` (HTTP 422) without invoking `Fire`, so user-configured `OnUnhandledTrigger` callbacks do not run. Call Stateless `Fire` directly when that callback policy is desired.
+- `InvalidOperationException` thrown while evaluating a guard is translated to `Error.InvalidInput` with the guard exception message. Other exception types and exceptions thrown by user entry, exit, transition, accessor, mutator, or configuration code are not swallowed.
+- `LazyStateMachine<TState, TTrigger>` exists to defer state-machine construction until after entity state is available, which is useful when ORMs materialize an object before populating its state properties.
+
+## Scope boundary — async and parameterized triggers
+
+`Trellis.StateMachine` deliberately wraps only the synchronous, parameterless trigger shape `Fire(TTrigger)`. Stateless also supports:
+
+- `FireAsync(TTrigger)` and the parameterized async overloads for state machines with `OnEntryAsync`/`OnExitAsync`/`OnActivateAsync` callbacks.
+- Parameterized triggers via `SetTriggerParameters<TArg>(...)` (returning a `TriggerWithParameters<TArg>` token) and `Fire(triggerWithParameters, arg)` / `FireAsync(triggerWithParameters, arg)` for passing context (timestamps, cancellation reasons, etc.) into transition actions.
+
+These shapes are **not** wrapped today. Consumers who need them must call the underlying Stateless APIs directly and translate exceptions themselves; the Trellis `Result<TState>` pipeline ends at the sync, no-arg boundary. If a future Trellis version adds `FireResultAsync` / parameterized overloads, they will follow the same `CanFire` short-circuit design and will use library-source `ConfigureAwait(false)` on awaited Stateless operations.
+
+## Code examples
+
+### Use `FireResult` on a regular Stateless machine
+
+```csharp
+using Stateless;
+using Trellis;
+using Trellis.StateMachine;
+
+enum OrderState { Draft, Submitted, Cancelled }
+enum OrderTrigger { Submit, Cancel }
+
+var machine = new StateMachine<OrderState, OrderTrigger>(OrderState.Draft);
+machine.Configure(OrderState.Draft)
+    .Permit(OrderTrigger.Submit, OrderState.Submitted)
+    .Permit(OrderTrigger.Cancel, OrderState.Cancelled);
+
+Result<OrderState> submitResult = machine.FireResult(OrderTrigger.Submit);
+Result<OrderState> invalidResult = machine.FireResult(OrderTrigger.Submit);
+```
+
+### Use `LazyStateMachine<TState, TTrigger>`
+
+```csharp
+using Stateless;
+using Trellis;
+using Trellis.StateMachine;
+
+enum DocumentState { Draft, Published }
+enum DocumentTrigger { Publish }
+
+var state = DocumentState.Draft;
+
+var lazyMachine = new LazyStateMachine<DocumentState, DocumentTrigger>(
+    () => state,
+    s => state = s,
+    machine => machine.Configure(DocumentState.Draft)
+        .Permit(DocumentTrigger.Publish, DocumentState.Published));
+
+Result<DocumentState> result = lazyMachine.FireResult(DocumentTrigger.Publish);
+StateMachine<DocumentState, DocumentTrigger> machine = lazyMachine.Machine;
+```
+
+## Cross-references
+
+- [trellis-api-core.md](trellis-api-core.md#public-abstract-record-error) — `Result<T>`, `Error.InvalidInput`, `RuleViolation`.
+- [trellis-api-cookbook.md](trellis-api-cookbook.md#recipe-9--state-machine-canfire--fire-pattern-with-fireresult) — Recipe 9: state-machine `CanFire` + `Fire` pattern with `FireResult`.
+- [trellis-api-asp.md](trellis-api-asp.md#domain--http-boundary-mapping) — how `Error.InvalidInput` renders as HTTP 422 (top-level `detail` reads `Error.Detail`; per-rule context reads `RuleViolation.Detail`).
+
+## Breaking changes from v1
+
+- **Package renamed:** `Trellis.Stateless` → `Trellis.StateMachine`. Vendor independence in the *name*, not the *implementation* — the underlying [Stateless](https://github.com/dotnet-state-machine/stateless) library is still referenced directly, and `StateMachine<TState, TTrigger>` from the `Stateless` namespace remains visible in user code.
+- **Namespace renamed:** `Trellis.Stateless` → `Trellis.StateMachine`. Replace `using Trellis.Stateless;` with `using Trellis.StateMachine;`.
+- **Public surface is otherwise identical:** `StateMachineExtensions.FireResult<TState, TTrigger>(...)` and `LazyStateMachine<TState, TTrigger>` are unchanged.
+- **No metapackage redirect.** The old `Trellis.Stateless` package is not shipped and there is no shim. Update your `PackageReference` directly.

--- a/Api/src/2022-12-21/Controllers/DinnersController.cs
+++ b/Api/src/2022-12-21/Controllers/DinnersController.cs
@@ -1,26 +1,147 @@
-﻿namespace BuberDinner._2022_12_21.Controllers;
+namespace BuberDinner._2022_12_21.Controllers;
 
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Asp.Versioning;
+using BuberDinner.Api._2022_12_21.Models.Dinners;
+using BuberDinner.Application.Dinners.Commands;
+using BuberDinner.Application.Dinners.Queries;
+using BuberDinner.Domain.Dinner.Entities;
+using BuberDinner.Domain.Dinner.ValueObject;
+using BuberDinner.Domain.Host.ValueObject;
+using Mapster;
+using Mediator;
 using Microsoft.AspNetCore.Mvc;
+using Trellis;
+using Trellis.Asp;
 
 /// <summary>
-/// CRUD for dinner.
+/// CRUD + lifecycle endpoints for the <see cref="Dinner"/> aggregate. State-transition POSTs
+/// (<c>/start</c>, <c>/end</c>, <c>/cancel</c>) are guarded by the aggregate's Stateless
+/// state machine — Cookbook Recipe 23 explicitly notes these endpoints do NOT need
+/// <c>If-Match</c>; an invalid transition is a semantic rule violation (422), not a
+/// concurrent-modification conflict (412).
 /// </summary>
 [ApiVersion("2022-10-01")]
-[Route("[controller]")]
-[Consumes("application/json")]
+[Route("hosts/{hostId:HostId}/dinners")]
 [Produces("application/json")]
 [ProducesResponseType(StatusCodes.Status401Unauthorized)]
 [ProducesResponseType(StatusCodes.Status200OK)]
 public class DinnersController : ControllerBase
 {
-    /// <summary>
-    /// Get all the dinners.
-    /// </summary>
-    /// <returns></returns>
-    [HttpGet]
-    public IActionResult ListDinners()
+    private readonly ISender _sender;
+
+    /// <summary>Initialises a new <see cref="DinnersController"/> with the supplied Mediator sender.</summary>
+    public DinnersController(ISender sender)
     {
-        return Ok(Array.Empty<string>());
+        _sender = sender;
     }
+
+    /// <summary>
+    /// Schedules a new dinner under the route host. The handler validates that the supplied
+    /// MenuId belongs to the same host (404 otherwise) and that EndDateTime &gt; StartDateTime
+    /// (422 otherwise). Resource auth (<see cref="Trellis.Authorization.IAuthorizeResource{T}"/>)
+    /// gates by Host ownership.
+    /// </summary>
+    [HttpPost]
+    [Consumes("application/json")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
+    public async ValueTask<ActionResult<DinnerResponse>> ScheduleDinner(
+        HostId hostId,
+        [FromBody] ScheduleDinnerRequest request,
+        CancellationToken cancellationToken) =>
+        await request.ToScheduleDinnerCommand(hostId)
+            .BindAsync(command => _sender.Send(command, cancellationToken))
+            .ToHttpResponseAsync(
+                body: dinner => dinner.Adapt<DinnerResponse>(),
+                configure: opts => opts
+                    .Created(dinner => $"/hosts/{hostId.Value}/dinners/{dinner.Id.Value}")
+                    .WithETag(dinner => EntityTagValue.Strong(dinner.ETag)))
+            .AsActionResultAsync<DinnerResponse>();
+
+    /// <summary>
+    /// Lists every dinner owned by the route host. PR 3 will replace this with paginated
+    /// <see cref="Trellis.Page{T}"/> + <see cref="Trellis.Cursor"/> output.
+    /// </summary>
+    [HttpGet]
+    public async ValueTask<ActionResult<DinnerResponse[]>> ListDinners(
+        HostId hostId, CancellationToken cancellationToken) =>
+        await _sender.Send(new ListDinnersForHostQuery(hostId), cancellationToken)
+            .ToHttpResponseAsync(
+                body: dinners => dinners.Select(d => d.Adapt<DinnerResponse>()).ToArray())
+            .AsActionResultAsync<DinnerResponse[]>();
+
+    /// <summary>
+    /// Get a dinner by id. Emits a strong ETag (Cookbook Recipe 6) — though dinners are
+    /// mutated only through the state-machine POSTs, the ETag still lets clients revalidate
+    /// cached reads with <c>If-None-Match</c> (304).
+    /// </summary>
+    [HttpGet("{dinnerId:DinnerId}")]
+    [ProducesResponseType(StatusCodes.Status304NotModified)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async ValueTask<ActionResult<DinnerResponse>> GetDinner(
+        HostId hostId, DinnerId dinnerId, CancellationToken cancellationToken) =>
+        await _sender.Send(new GetDinnerQuery(hostId, dinnerId), cancellationToken)
+            .ToHttpResponseAsync(
+                body: dinner => dinner.Adapt<DinnerResponse>(),
+                configure: opts => opts
+                    .WithETag(dinner => EntityTagValue.Strong(dinner.ETag))
+                    .EvaluatePreconditions())
+            .AsActionResultAsync<DinnerResponse>();
+
+    /// <summary>
+    /// Transitions the dinner to <c>InProgress</c>. Body-less per Cookbook Recipe 23.
+    /// Invalid transition (e.g. dinner already started or ended) → 422 with reason code
+    /// <c>state.machine.invalid.transition</c>.
+    /// </summary>
+    [HttpPost("{dinnerId:DinnerId}/start")]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
+    public async ValueTask<ActionResult<DinnerResponse>> StartDinner(
+        HostId hostId, DinnerId dinnerId, CancellationToken cancellationToken) =>
+        await _sender.Send(new StartDinnerCommand(hostId, dinnerId), cancellationToken)
+            .ToHttpResponseAsync(
+                body: dinner => dinner.Adapt<DinnerResponse>(),
+                configure: opts => opts.WithETag(dinner => EntityTagValue.Strong(dinner.ETag)))
+            .AsActionResultAsync<DinnerResponse>();
+
+    /// <summary>
+    /// Transitions the dinner to <c>Ended</c>. Body-less.
+    /// </summary>
+    [HttpPost("{dinnerId:DinnerId}/end")]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
+    public async ValueTask<ActionResult<DinnerResponse>> EndDinner(
+        HostId hostId, DinnerId dinnerId, CancellationToken cancellationToken) =>
+        await _sender.Send(new EndDinnerCommand(hostId, dinnerId), cancellationToken)
+            .ToHttpResponseAsync(
+                body: dinner => dinner.Adapt<DinnerResponse>(),
+                configure: opts => opts.WithETag(dinner => EntityTagValue.Strong(dinner.ETag)))
+            .AsActionResultAsync<DinnerResponse>();
+
+    /// <summary>
+    /// Transitions the dinner to <c>Cancelled</c>, recording the supplied reason. Not
+    /// permitted once the dinner has started — see Cookbook Recipe 9 §697.
+    /// </summary>
+    [HttpPost("{dinnerId:DinnerId}/cancel")]
+    [Consumes("application/json")]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
+    public async ValueTask<ActionResult<DinnerResponse>> CancelDinner(
+        HostId hostId,
+        DinnerId dinnerId,
+        [FromBody] CancelDinnerRequest request,
+        CancellationToken cancellationToken) =>
+        await _sender.Send(new CancelDinnerCommand(hostId, dinnerId, request.Reason ?? string.Empty), cancellationToken)
+            .ToHttpResponseAsync(
+                body: dinner => dinner.Adapt<DinnerResponse>(),
+                configure: opts => opts.WithETag(dinner => EntityTagValue.Strong(dinner.ETag)))
+            .AsActionResultAsync<DinnerResponse>();
 }

--- a/Api/src/2022-12-21/Models/Dinners/DinnerMappingConfig.cs
+++ b/Api/src/2022-12-21/Models/Dinners/DinnerMappingConfig.cs
@@ -1,0 +1,23 @@
+namespace BuberDinner.Api._2022_12_21.Models.Dinners;
+
+using BuberDinner.Domain.Dinner.Entities;
+using Mapster;
+
+/// <summary>
+/// Mapster mapping config from the <see cref="Dinner"/> aggregate to <see cref="DinnerResponse"/>.
+/// Auto-discovered by <c>config.Scan(Assembly.GetExecutingAssembly())</c> in Api/DI.
+/// </summary>
+public sealed class DinnerMappingConfig : IRegister
+{
+    /// <summary>Registers the <see cref="Dinner"/> → <see cref="DinnerResponse"/> mapping.</summary>
+    public void Register(TypeAdapterConfig config)
+    {
+        config.NewConfig<Dinner, DinnerResponse>()
+            .Map(dest => dest.Id, src => src.Id.Value.ToString())
+            .Map(dest => dest.Name, src => src.Name.Value)
+            .Map(dest => dest.Description, src => src.Description.Value)
+            .Map(dest => dest.HostId, src => src.HostId.Value.ToString())
+            .Map(dest => dest.MenuId, src => src.MenuId.Value.ToString())
+            .Map(dest => dest.Status, src => src.Status.Value);
+    }
+}

--- a/Api/src/2022-12-21/Models/Dinners/DinnerRequests.cs
+++ b/Api/src/2022-12-21/Models/Dinners/DinnerRequests.cs
@@ -1,0 +1,30 @@
+namespace BuberDinner.Api._2022_12_21.Models.Dinners;
+
+using System;
+using BuberDinner.Application.Dinners.Commands;
+using BuberDinner.Domain.Host.ValueObject;
+using DescriptionClass = BuberDinner.Domain.Common.ValueObjects.Description;
+using MenuIdClass = BuberDinner.Domain.Menu.ValueObject.MenuId;
+using NameClass = BuberDinner.Domain.Common.ValueObjects.Name;
+
+/// <summary>Schedule-dinner request body (POST /hosts/{hostId}/dinners).</summary>
+public record ScheduleDinnerRequest(
+    string Name,
+    string Description,
+    string MenuId,
+    DateTimeOffset StartDateTime,
+    DateTimeOffset EndDateTime)
+{
+    /// <summary>Validates the request fields and lifts them into a <see cref="ScheduleDinnerCommand"/>.</summary>
+    public Result<ScheduleDinnerCommand> ToScheduleDinnerCommand(HostId hostId) =>
+        NameClass.TryCreate(this.Name)
+            .Combine(DescriptionClass.TryCreate(this.Description))
+            .Combine(MenuIdClass.TryCreate(this.MenuId))
+            .Bind((name, description, menuId) =>
+                ScheduleDinnerCommand.TryCreate(
+                    hostId, menuId, name, description,
+                    this.StartDateTime, this.EndDateTime));
+}
+
+/// <summary>Cancel-dinner request body (POST /hosts/{hostId}/dinners/{dinnerId}/cancel).</summary>
+public record CancelDinnerRequest(string Reason);

--- a/Api/src/2022-12-21/Models/Dinners/DinnerResponse.cs
+++ b/Api/src/2022-12-21/Models/Dinners/DinnerResponse.cs
@@ -1,0 +1,21 @@
+namespace BuberDinner.Api._2022_12_21.Models.Dinners;
+
+using System;
+
+/// <summary>
+/// Wire representation of a <see cref="Domain.Dinner.Entities.Dinner"/>. The same shape
+/// is returned by GET, POST (schedule), and the state-transition POSTs (/start, /end, /cancel).
+/// </summary>
+public record DinnerResponse(
+    string Id,
+    string Name,
+    string Description,
+    string HostId,
+    string MenuId,
+    string Status,
+    DateTimeOffset StartDateTime,
+    DateTimeOffset EndDateTime,
+    DateTimeOffset? StartedAt,
+    DateTimeOffset? EndedAt,
+    DateTimeOffset? CancelledAt,
+    string? CancellationReason);

--- a/Api/src/DependencyInjection.cs
+++ b/Api/src/DependencyInjection.cs
@@ -1,8 +1,11 @@
 ﻿namespace BuberDinner.Api;
 
 using System.Reflection;
+using BuberDinner.Application.Dinners.Events;
 using BuberDinner.Application.Hosts.Authorization;
 using BuberDinner.Application.Menus.Commands;
+using BuberDinner.Domain.Dinner.Events;
+using BuberDinner.Domain.Dinner.ValueObject;
 using BuberDinner.Domain.Host.ValueObject;
 using BuberDinner.Domain.Menu.ValueObject;
 using Mapster;
@@ -23,9 +26,10 @@ internal static class DependencyInjection
         services.AddTrellisAspWithScalarValidation();
 
         // Scalar value-object route constraints — let MVC bind `{hostId:HostId}` / `{menuId:MenuId}`
-        // straight into typed VOs at the boundary (instead of string-then-reparse-in-DTO).
+        // / `{dinnerId:DinnerId}` straight into typed VOs at the boundary.
         services.AddTrellisRouteConstraint<HostId>(nameof(HostId));
         services.AddTrellisRouteConstraint<MenuId>(nameof(MenuId));
+        services.AddTrellisRouteConstraint<DinnerId>(nameof(DinnerId));
 
         // Resource-based authorization wiring: ClaimsActorProvider reads the JWT `sub` claim
         // and the SharedResourceLoaderById<Host, HostId> in the Application assembly authorizes
@@ -34,6 +38,19 @@ internal static class DependencyInjection
         services.AddResourceAuthorization(
             typeof(UpdateMenuCommand).Assembly,   // Application — commands + IAuthorizeResource implementations
             typeof(HostResourceLoader).Assembly); // Same assembly today; named for clarity / future ACL split
+
+        // Domain event dispatch (Cookbook Recipe 17): explicit per-handler registration is
+        // AOT-safe and surfaces intent at the registration site. Each Dinner state transition
+        // raises exactly one event; each event has a single side-effect-only logging handler.
+        services.AddDomainEventDispatch();
+        services.AddDomainEventHandler<DinnerScheduled, LogDinnerScheduledHandler>();
+        services.AddDomainEventHandler<DinnerStarted, LogDinnerStartedHandler>();
+        services.AddDomainEventHandler<DinnerEnded, LogDinnerEndedHandler>();
+        services.AddDomainEventHandler<DinnerCancelled, LogDinnerCancelledHandler>();
+
+        // .NET 8 testable clock — handlers inject TimeProvider rather than DateTime.UtcNow so
+        // tests can pin the clock via FakeTimeProvider (Cookbook Recipe 17 §1319).
+        services.AddSingleton(TimeProvider.System);
 
         services.AddMappings();
         services.AddApiVersioning(

--- a/Api/tests/2022-12-21/DinnerStateMachineTests.cs
+++ b/Api/tests/2022-12-21/DinnerStateMachineTests.cs
@@ -1,0 +1,403 @@
+namespace BuberDinner.Api.Tests._2022_12_21;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BuberDinner.Application.Dinners.Events;
+using BuberDinner.Domain.Dinner.Events;
+using Mediator;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis.Mediator;
+using Xunit.Priority;
+
+/// <summary>
+/// End-to-end coverage for the Dinner aggregate, state machine, and domain-event dispatch.
+/// Each test boots a fresh <see cref="WebApplicationFactory{TEntryPoint}"/> with the
+/// captured-events handler swapped in so the test can assert "this event was published
+/// with this OccurredAt" after the request returns.
+/// </summary>
+[TestCaseOrderer(PriorityOrderer.Name, PriorityOrderer.Assembly)]
+public class DinnerStateMachineTests
+{
+    private const string ApiVersionQuery = "?api-version=2022-10-01";
+
+    [Fact, Priority(3)]
+    public async Task Schedule_dinner_returns_201_with_etag_and_publishes_DinnerScheduled()
+    {
+        var capture = new CapturedEvents();
+        var (client, hostId, menuId) = await SetupHostAndMenuAsync(capture);
+
+        var response = await SendScheduleAsync(client, hostId, menuId, "Brunch", "Sunday brunch");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.ETag.Should().NotBeNull();
+        response.Headers.Location.Should().NotBeNull();
+        response.Headers.Location!.OriginalString.Should().StartWith($"/hosts/{hostId}/dinners/");
+
+        var body = await response.Content.ReadAsAsync<DinnerResponseBody>();
+        body!.Status.Should().Be("Upcoming");
+
+        capture.Scheduled.Should().ContainSingle().Which.HostId.Value.ToString().Should().Be(hostId);
+    }
+
+    [Fact, Priority(3)]
+    public async Task Schedule_dinner_with_foreign_menu_returns_404()
+    {
+        var capture = new CapturedEvents();
+        var (clientA, hostA, _) = await SetupHostAndMenuAsync(capture);
+
+        // Register a second host (with its own menu) using the SAME WebApplicationFactory so
+        // both Hosts live in the same in-memory store the controller will read.
+        var (_, _, foreignMenuId) = await SetupSecondHostInSameFactoryAsync(clientA);
+
+        var response = await SendScheduleAsync(clientA, hostA, foreignMenuId, "x", "y");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var body = await response.Content.ReadAsAsync<ProblemDetailsWithCode>();
+        body!.Detail.Should().Contain("Menu does not belong to the specified host.");
+    }
+
+    [Fact, Priority(3)]
+    public async Task Full_lifecycle_Upcoming_to_Ended_publishes_all_three_events()
+    {
+        var capture = new CapturedEvents();
+        var (client, hostId, menuId) = await SetupHostAndMenuAsync(capture);
+        var dinnerId = await ScheduleDinnerAsync(client, hostId, menuId);
+
+        var startResponse = await client.PostAsync(TransitionUrl(hostId, dinnerId, "start"), EmptyJsonBody());
+        startResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await startResponse.Content.ReadAsAsync<DinnerResponseBody>())!.Status.Should().Be("InProgress");
+
+        var endResponse = await client.PostAsync(TransitionUrl(hostId, dinnerId, "end"), EmptyJsonBody());
+        endResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var ended = await endResponse.Content.ReadAsAsync<DinnerResponseBody>();
+        ended!.Status.Should().Be("Ended");
+        ended.StartedAt.Should().NotBeNull();
+        ended.EndedAt.Should().NotBeNull();
+        ended.EndedAt!.Value.Should().BeAfter(ended.StartedAt!.Value);
+
+        capture.Scheduled.Should().HaveCount(1);
+        capture.Started.Should().HaveCount(1);
+        capture.Ended.Should().HaveCount(1);
+        capture.Cancelled.Should().BeEmpty();
+    }
+
+    [Fact, Priority(3)]
+    public async Task Start_when_already_InProgress_returns_422_with_state_machine_reason_code()
+    {
+        var (client, hostId, menuId) = await SetupHostAndMenuAsync(new CapturedEvents());
+        var dinnerId = await ScheduleDinnerAsync(client, hostId, menuId);
+        (await client.PostAsync(TransitionUrl(hostId, dinnerId, "start"), EmptyJsonBody())).EnsureSuccessStatusCode();
+
+        var response = await client.PostAsync(TransitionUrl(hostId, dinnerId, "start"), EmptyJsonBody());
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        var problem = await response.Content.ReadAsAsync<ProblemDetailsWithRules>();
+        problem!.Rules.Should().NotBeNull().And.Subject!.Should().ContainSingle()
+            .Which.Code.Should().Be("state.machine.invalid.transition");
+    }
+
+    [Fact, Priority(3)]
+    public async Task Cancel_from_Upcoming_returns_200_with_reason_and_publishes_DinnerCancelled()
+    {
+        var capture = new CapturedEvents();
+        var (client, hostId, menuId) = await SetupHostAndMenuAsync(capture);
+        var dinnerId = await ScheduleDinnerAsync(client, hostId, menuId);
+
+        var response = await client.PostAsync(
+            TransitionUrl(hostId, dinnerId, "cancel"),
+            JsonBody(new { reason = "host illness" }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsAsync<DinnerResponseBody>();
+        body!.Status.Should().Be("Cancelled");
+        body.CancellationReason.Should().Be("host illness");
+        body.CancelledAt.Should().NotBeNull();
+        body.EndedAt.Should().BeNull("Cancelled and Ended are semantically distinct");
+        capture.Cancelled.Should().ContainSingle().Which.Reason.Should().Be("host illness");
+    }
+
+    [Fact, Priority(3)]
+    public async Task Cancel_from_InProgress_returns_422_and_does_not_mutate_state()
+    {
+        var (client, hostId, menuId) = await SetupHostAndMenuAsync(new CapturedEvents());
+        var dinnerId = await ScheduleDinnerAsync(client, hostId, menuId);
+        (await client.PostAsync(TransitionUrl(hostId, dinnerId, "start"), EmptyJsonBody())).EnsureSuccessStatusCode();
+
+        var response = await client.PostAsync(
+            TransitionUrl(hostId, dinnerId, "cancel"),
+            JsonBody(new { reason = "too late" }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+
+        var get = await client.GetAsync(DinnerUrl(hostId, dinnerId));
+        var current = await get.Content.ReadAsAsync<DinnerResponseBody>();
+        current!.Status.Should().Be("InProgress", "rejected transitions must not mutate state");
+        current.CancellationReason.Should().BeNull();
+    }
+
+    [Fact, Priority(3)]
+    public async Task Cross_host_start_returns_403_forbidden()
+    {
+        var (ownerClient, hostId, menuId) = await SetupHostAndMenuAsync(new CapturedEvents());
+        var dinnerId = await ScheduleDinnerAsync(ownerClient, hostId, menuId);
+
+        // Reuse the same WebApplicationFactory by registering a second user on the same client
+        // surface. We need a separate token, so we build a fresh client and register independently.
+        var (intruderClient, _, _) = await SetupHostAndMenuAsync(new CapturedEvents());
+
+        var response = await intruderClient.PostAsync(TransitionUrl(hostId, dinnerId, "start"), EmptyJsonBody());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        var problem = await response.Content.ReadAsAsync<ProblemDetailsWithCode>();
+        problem!.Code.Should().Be("dinners.owner");
+    }
+
+    [Fact, Priority(3)]
+    public async Task List_dinners_returns_only_host_owned_dinners()
+    {
+        var (client, hostId, menuId) = await SetupHostAndMenuAsync(new CapturedEvents());
+        await ScheduleDinnerAsync(client, hostId, menuId);
+        await ScheduleDinnerAsync(client, hostId, menuId);
+
+        var response = await client.GetAsync(DinnersUrl(hostId));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var list = await response.Content.ReadAsAsync<DinnerResponseBody[]>();
+        list!.Length.Should().BeGreaterOrEqualTo(2);
+        list.Should().OnlyContain(d => d.HostId == hostId);
+    }
+
+    // ------------------------ helpers ------------------------
+
+    private static string DinnersUrl(string hostId) => $"hosts/{hostId}/dinners{ApiVersionQuery}";
+    private static string DinnerUrl(string hostId, string dinnerId) =>
+        $"hosts/{hostId}/dinners/{dinnerId}{ApiVersionQuery}";
+    private static string TransitionUrl(string hostId, string dinnerId, string action) =>
+        $"hosts/{hostId}/dinners/{dinnerId}/{action}{ApiVersionQuery}";
+
+    /// <summary>
+    /// Spins up a fresh WebApplicationFactory wired with the supplied <see cref="CapturedEvents"/>
+    /// sink (each Dinner event handler appends to the matching list), registers a unique user,
+    /// creates a Host owned by them, and a Menu under that Host. Returns an authenticated client
+    /// + the new HostId + MenuId.
+    /// </summary>
+    private async Task<(HttpClient client, string hostId, string menuId)> SetupHostAndMenuAsync(CapturedEvents capture)
+    {
+        var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(b =>
+            b.ConfigureServices(services =>
+            {
+                services.AddSingleton(capture);
+                services.AddScoped<IDomainEventHandler<DinnerScheduled>, CapturingScheduledHandler>();
+                services.AddScoped<IDomainEventHandler<DinnerStarted>, CapturingStartedHandler>();
+                services.AddScoped<IDomainEventHandler<DinnerEnded>, CapturingEndedHandler>();
+                services.AddScoped<IDomainEventHandler<DinnerCancelled>, CapturingCancelledHandler>();
+            }));
+
+        var client = factory.CreateClient();
+        var userId = $"u_{Guid.NewGuid():N}".Substring(0, 16);
+        var registerBody = $$"""
+            {
+              "userId": "{{userId}}",
+              "firstName": "F",
+              "lastName": "L",
+              "email": "{{userId}}@example.com",
+              "password": "SecretP2$$word"
+            }
+            """;
+        var registerResponse = await client.PostAsync("authentication/register",
+            new StringContent(registerBody, Encoding.UTF8, "application/json"));
+        registerResponse.EnsureSuccessStatusCode();
+        var token = (await registerResponse.Content.ReadAsAsync<TokenReply>())!.Token;
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var hostResponse = await client.PostAsync($"hosts{ApiVersionQuery}",
+            JsonBody(new { displayName = "Test Kitchen" }));
+        hostResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var hostId = (await hostResponse.Content.ReadAsAsync<IdAndOwner>())!.Id;
+
+        var menuResponse = await client.PostAsync($"hosts/{hostId}/menus/create{ApiVersionQuery}", JsonBody(new
+        {
+            name = "Brunch Menu",
+            description = "Sunday brunch",
+            sections = new[]
+            {
+                new
+                {
+                    name = "Eggs",
+                    description = "Egg dishes",
+                    items = new[] { new { name = "Omelette", description = "Three-egg omelette" } }
+                }
+            }
+        }));
+        menuResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var menuId = (await menuResponse.Content.ReadAsAsync<IdOnly>())!.Id;
+
+        return (client, hostId, menuId);
+    }
+
+    /// <summary>
+    /// Registers a second user against the supplied client's WebApplicationFactory (so the same
+    /// in-memory User repo is reused) and creates a Host + Menu owned by THAT user. Used by the
+    /// "foreign menu" test to manufacture cross-host data without spinning up a separate
+    /// WebApplicationFactory (which would have its own in-memory store).
+    /// </summary>
+    private static async Task<(string token, string hostId, string menuId)> SetupSecondHostInSameFactoryAsync(HttpClient existingClient)
+    {
+        // Recreate the HTTP client off the original factory by sending a register request — the
+        // user goes into the same static in-memory store. We clone DefaultRequestHeaders via a
+        // separate "client", but the actual factory backing it is shared globally via static
+        // state in *InMemoryRepository.
+        var userId = $"u_{Guid.NewGuid():N}".Substring(0, 16);
+        var registerBody = $$"""
+            {
+              "userId": "{{userId}}", "firstName": "F", "lastName": "L",
+              "email": "{{userId}}@example.com", "password": "SecretP2$$word"
+            }
+            """;
+        var registerResponse = await existingClient.PostAsync("authentication/register",
+            new StringContent(registerBody, Encoding.UTF8, "application/json"));
+        registerResponse.EnsureSuccessStatusCode();
+        var token = (await registerResponse.Content.ReadAsAsync<TokenReply>())!.Token;
+
+        // Build a sibling request with the new user's token (don't mutate the caller's auth header).
+        var hostReq = new HttpRequestMessage(HttpMethod.Post, $"hosts{ApiVersionQuery}")
+        {
+            Content = JsonBody(new { displayName = "Foreign Kitchen" })
+        };
+        hostReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var hostResponse = await existingClient.SendAsync(hostReq);
+        hostResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var hostId = (await hostResponse.Content.ReadAsAsync<IdAndOwner>())!.Id;
+
+        var menuReq = new HttpRequestMessage(HttpMethod.Post, $"hosts/{hostId}/menus/create{ApiVersionQuery}")
+        {
+            Content = JsonBody(new
+            {
+                name = "Foreign Menu",
+                description = "Other host's menu",
+                sections = new[]
+                {
+                    new
+                    {
+                        name = "S",
+                        description = "d",
+                        items = new[] { new { name = "I", description = "d" } }
+                    }
+                }
+            })
+        };
+        menuReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var menuResponse = await existingClient.SendAsync(menuReq);
+        menuResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var menuId = (await menuResponse.Content.ReadAsAsync<IdOnly>())!.Id;
+
+        return (token, hostId, menuId);
+    }
+
+    private static async Task<HttpResponseMessage> SendScheduleAsync(
+        HttpClient client, string hostId, string menuId, string name, string description) =>
+        await client.PostAsync(DinnersUrl(hostId), JsonBody(new
+        {
+            name,
+            description,
+            menuId,
+            startDateTime = "2026-07-01T18:00:00Z",
+            endDateTime = "2026-07-01T21:00:00Z",
+        }));
+
+    private static async Task<string> ScheduleDinnerAsync(HttpClient client, string hostId, string menuId)
+    {
+        var response = await SendScheduleAsync(client, hostId, menuId, "Brunch", "Sunday brunch");
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var body = await response.Content.ReadAsAsync<DinnerResponseBody>();
+        return body!.Id;
+    }
+
+    private static StringContent JsonBody(object payload) =>
+        new(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+    private static StringContent EmptyJsonBody() => new(string.Empty, Encoding.UTF8, "application/json");
+
+    // ----- Captured-events sink: scoped per WebApplicationFactory (each test owns one). -----
+
+    public sealed class CapturedEvents
+    {
+        public List<DinnerScheduled> Scheduled { get; } = new();
+        public List<DinnerStarted> Started { get; } = new();
+        public List<DinnerEnded> Ended { get; } = new();
+        public List<DinnerCancelled> Cancelled { get; } = new();
+    }
+
+    private sealed class CapturingScheduledHandler : IDomainEventHandler<DinnerScheduled>
+    {
+        private readonly CapturedEvents _events;
+        public CapturingScheduledHandler(CapturedEvents events) => _events = events;
+        public ValueTask HandleAsync(DinnerScheduled n, CancellationToken ct)
+        {
+            lock (_events.Scheduled) _events.Scheduled.Add(n);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class CapturingStartedHandler : IDomainEventHandler<DinnerStarted>
+    {
+        private readonly CapturedEvents _events;
+        public CapturingStartedHandler(CapturedEvents events) => _events = events;
+        public ValueTask HandleAsync(DinnerStarted n, CancellationToken ct)
+        {
+            lock (_events.Started) _events.Started.Add(n);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class CapturingEndedHandler : IDomainEventHandler<DinnerEnded>
+    {
+        private readonly CapturedEvents _events;
+        public CapturingEndedHandler(CapturedEvents events) => _events = events;
+        public ValueTask HandleAsync(DinnerEnded n, CancellationToken ct)
+        {
+            lock (_events.Ended) _events.Ended.Add(n);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class CapturingCancelledHandler : IDomainEventHandler<DinnerCancelled>
+    {
+        private readonly CapturedEvents _events;
+        public CapturingCancelledHandler(CapturedEvents events) => _events = events;
+        public ValueTask HandleAsync(DinnerCancelled n, CancellationToken ct)
+        {
+            lock (_events.Cancelled) _events.Cancelled.Add(n);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    // ----- wire shapes -----
+
+    private sealed record TokenReply(string Token);
+
+    private sealed record IdAndOwner(string Id, string OwnerId, string DisplayName);
+
+    private sealed record IdOnly(string Id);
+
+    private sealed record DinnerResponseBody(
+        string Id, string Name, string Description, string HostId, string MenuId,
+        string Status, DateTimeOffset StartDateTime, DateTimeOffset EndDateTime,
+        DateTimeOffset? StartedAt, DateTimeOffset? EndedAt, DateTimeOffset? CancelledAt,
+        string? CancellationReason);
+
+    private sealed record ProblemDetailsWithCode(int Status, string? Code, string? Kind, string? Detail);
+
+    private sealed record ProblemDetailsWithRules(int Status, string? Code, List<RuleEntry>? Rules);
+
+    private sealed record RuleEntry(string Code, string? Detail);
+}

--- a/Application/src/Abstractions/Persistence/IDinnerRepository.cs
+++ b/Application/src/Abstractions/Persistence/IDinnerRepository.cs
@@ -1,0 +1,19 @@
+namespace BuberDinner.Application.Abstractions.Persistence;
+
+using System.Collections.Generic;
+using BuberDinner.Domain.Dinner.Entities;
+using BuberDinner.Domain.Host.ValueObject;
+
+/// <summary>
+/// Dinner-specific repository surface. Extends the generic <see cref="IRepository{T}"/>
+/// with a per-host listing primitive so the application layer doesn't have to depend on
+/// any particular persistence implementation (or filter in memory after a full load).
+/// </summary>
+/// <remarks>
+/// PR 2 ships the in-memory implementation only; PR 3 will introduce a paginated
+/// equivalent (<c>Page&lt;Dinner&gt;</c> + <c>Cursor</c>) and the EF Core implementation.
+/// </remarks>
+public interface IDinnerRepository : IRepository<Dinner>
+{
+    IReadOnlyList<Dinner> GetForHost(HostId hostId);
+}

--- a/Application/src/Dinners/Commands/DinnerTransitionCommandHandlers.cs
+++ b/Application/src/Dinners/Commands/DinnerTransitionCommandHandlers.cs
@@ -1,0 +1,87 @@
+namespace BuberDinner.Application.Dinners.Commands;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.Dinner.Entities;
+using Mediator;
+
+/// <summary>
+/// Shared transition shape: load the dinner, verify route-host membership, invoke the
+/// supplied domain transition (returns <see cref="Result{Dinner}"/>), persist on success.
+/// </summary>
+internal static class DinnerTransitionPipeline
+{
+    public static async ValueTask<Result<Dinner>> ApplyAsync(
+        IRepository<Dinner> repo,
+        BuberDinner.Domain.Host.ValueObject.HostId expectedHostId,
+        BuberDinner.Domain.Dinner.ValueObject.DinnerId dinnerId,
+        Func<Dinner, Result<Dinner>> transition,
+        CancellationToken cancellationToken)
+    {
+        var dinner = await repo.FindById(dinnerId.Value.ToString(), cancellationToken);
+        if (dinner is null)
+            return Result.Fail<Dinner>(new Error.NotFound(ResourceRef.For<Dinner>(dinnerId)));
+        if (dinner.HostId != expectedHostId)
+            return Result.Fail<Dinner>(new Error.NotFound(ResourceRef.For<Dinner>(dinnerId))
+            {
+                Detail = "Dinner does not belong to the specified host.",
+            });
+
+        var transitionResult = transition(dinner);
+        if (transitionResult.IsFailure)
+            return transitionResult;
+
+        await repo.Update(dinner, cancellationToken);
+        return transitionResult;
+    }
+}
+
+public sealed class StartDinnerCommandHandler : ICommandHandler<StartDinnerCommand, Result<Dinner>>
+{
+    private readonly IRepository<Dinner> _repo;
+    private readonly TimeProvider _clock;
+
+    public StartDinnerCommandHandler(IRepository<Dinner> repo, TimeProvider clock)
+    {
+        _repo = repo;
+        _clock = clock;
+    }
+
+    public ValueTask<Result<Dinner>> Handle(StartDinnerCommand request, CancellationToken cancellationToken) =>
+        DinnerTransitionPipeline.ApplyAsync(_repo, request.HostId, request.DinnerId,
+            dinner => dinner.Start(_clock), cancellationToken);
+}
+
+public sealed class EndDinnerCommandHandler : ICommandHandler<EndDinnerCommand, Result<Dinner>>
+{
+    private readonly IRepository<Dinner> _repo;
+    private readonly TimeProvider _clock;
+
+    public EndDinnerCommandHandler(IRepository<Dinner> repo, TimeProvider clock)
+    {
+        _repo = repo;
+        _clock = clock;
+    }
+
+    public ValueTask<Result<Dinner>> Handle(EndDinnerCommand request, CancellationToken cancellationToken) =>
+        DinnerTransitionPipeline.ApplyAsync(_repo, request.HostId, request.DinnerId,
+            dinner => dinner.End(_clock), cancellationToken);
+}
+
+public sealed class CancelDinnerCommandHandler : ICommandHandler<CancelDinnerCommand, Result<Dinner>>
+{
+    private readonly IRepository<Dinner> _repo;
+    private readonly TimeProvider _clock;
+
+    public CancelDinnerCommandHandler(IRepository<Dinner> repo, TimeProvider clock)
+    {
+        _repo = repo;
+        _clock = clock;
+    }
+
+    public ValueTask<Result<Dinner>> Handle(CancelDinnerCommand request, CancellationToken cancellationToken) =>
+        DinnerTransitionPipeline.ApplyAsync(_repo, request.HostId, request.DinnerId,
+            dinner => dinner.Cancel(request.Reason, _clock), cancellationToken);
+}

--- a/Application/src/Dinners/Commands/DinnerTransitionCommands.cs
+++ b/Application/src/Dinners/Commands/DinnerTransitionCommands.cs
@@ -1,0 +1,81 @@
+namespace BuberDinner.Application.Dinners.Commands;
+
+using BuberDinner.Domain.Dinner.Entities;
+using BuberDinner.Domain.Dinner.ValueObject;
+using BuberDinner.Domain.Host.Entities;
+using BuberDinner.Domain.Host.ValueObject;
+using Mediator;
+using Trellis.Authorization;
+
+/// <summary>
+/// Transitions a <see cref="Dinner"/> from <c>Upcoming</c> to <c>InProgress</c>.
+/// Body-less per Cookbook Recipe 23 (state-machine guard substitutes for <c>If-Match</c>).
+/// </summary>
+public sealed class StartDinnerCommand
+    : ICommand<Result<Dinner>>, IAuthorizeResource<Host>, IIdentifyResource<Host, HostId>
+{
+    public HostId HostId { get; }
+    public DinnerId DinnerId { get; }
+
+    public StartDinnerCommand(HostId hostId, DinnerId dinnerId)
+    {
+        HostId = hostId;
+        DinnerId = dinnerId;
+    }
+
+    public HostId GetResourceId() => HostId;
+
+    public IResult Authorize(Actor actor, Host host) =>
+        host.OwnerId.Value == actor.Id.Value
+            ? Result.Ok()
+            : Result.Fail(new Error.Forbidden("dinners.owner", ResourceRef.For<Host>(HostId)));
+}
+
+/// <summary>
+/// Transitions a <see cref="Dinner"/> from <c>InProgress</c> to <c>Ended</c>.
+/// </summary>
+public sealed class EndDinnerCommand
+    : ICommand<Result<Dinner>>, IAuthorizeResource<Host>, IIdentifyResource<Host, HostId>
+{
+    public HostId HostId { get; }
+    public DinnerId DinnerId { get; }
+
+    public EndDinnerCommand(HostId hostId, DinnerId dinnerId)
+    {
+        HostId = hostId;
+        DinnerId = dinnerId;
+    }
+
+    public HostId GetResourceId() => HostId;
+
+    public IResult Authorize(Actor actor, Host host) =>
+        host.OwnerId.Value == actor.Id.Value
+            ? Result.Ok()
+            : Result.Fail(new Error.Forbidden("dinners.owner", ResourceRef.For<Host>(HostId)));
+}
+
+/// <summary>
+/// Transitions a <see cref="Dinner"/> from <c>Upcoming</c> to <c>Cancelled</c>, recording
+/// the supplied reason. Not permitted once the dinner has started.
+/// </summary>
+public sealed class CancelDinnerCommand
+    : ICommand<Result<Dinner>>, IAuthorizeResource<Host>, IIdentifyResource<Host, HostId>
+{
+    public HostId HostId { get; }
+    public DinnerId DinnerId { get; }
+    public string Reason { get; }
+
+    public CancelDinnerCommand(HostId hostId, DinnerId dinnerId, string reason)
+    {
+        HostId = hostId;
+        DinnerId = dinnerId;
+        Reason = reason;
+    }
+
+    public HostId GetResourceId() => HostId;
+
+    public IResult Authorize(Actor actor, Host host) =>
+        host.OwnerId.Value == actor.Id.Value
+            ? Result.Ok()
+            : Result.Fail(new Error.Forbidden("dinners.owner", ResourceRef.For<Host>(HostId)));
+}

--- a/Application/src/Dinners/Commands/ScheduleDinnerCommand.cs
+++ b/Application/src/Dinners/Commands/ScheduleDinnerCommand.cs
@@ -1,0 +1,58 @@
+namespace BuberDinner.Application.Dinners.Commands;
+
+using BuberDinner.Domain.Common.ValueObjects;
+using BuberDinner.Domain.Dinner.Entities;
+using BuberDinner.Domain.Host.Entities;
+using BuberDinner.Domain.Host.ValueObject;
+using BuberDinner.Domain.Menu.ValueObject;
+using Mediator;
+using Trellis.Authorization;
+
+/// <summary>
+/// Schedules a new <see cref="Dinner"/> owned by the supplied <see cref="HostId"/>.
+/// Implements <see cref="ICommand{TResponse}"/> (not <c>IRequest</c>) so the
+/// <c>DomainEventDispatchBehavior</c> pipeline picks up the resulting aggregate's
+/// <c>UncommittedEvents()</c> and fans <see cref="Domain.Dinner.Events.DinnerScheduled"/>
+/// out to every registered handler.
+/// </summary>
+/// <remarks>
+/// Authorization is resource-based via <see cref="IAuthorizeResource{TResource}"/> +
+/// <see cref="IIdentifyResource{TResource, TId}"/>: the authenticated actor must equal
+/// <see cref="Host.OwnerId"/>. The handler additionally verifies that the supplied
+/// <see cref="MenuId"/> belongs to the same host (returns <see cref="Error.NotFound"/>
+/// otherwise) — without that check a host could schedule against another host's menu.
+/// </remarks>
+public sealed class ScheduleDinnerCommand
+    : ICommand<Result<Dinner>>, IAuthorizeResource<Host>, IIdentifyResource<Host, HostId>
+{
+    public HostId HostId { get; }
+    public MenuId MenuId { get; }
+    public Name Name { get; }
+    public Description Description { get; }
+    public DateTimeOffset StartDateTime { get; }
+    public DateTimeOffset EndDateTime { get; }
+
+    public static Result<ScheduleDinnerCommand> TryCreate(
+        HostId hostId, MenuId menuId, Name name, Description description,
+        DateTimeOffset startDateTime, DateTimeOffset endDateTime) =>
+        Result.Ok(new ScheduleDinnerCommand(hostId, menuId, name, description, startDateTime, endDateTime));
+
+    private ScheduleDinnerCommand(
+        HostId hostId, MenuId menuId, Name name, Description description,
+        DateTimeOffset startDateTime, DateTimeOffset endDateTime)
+    {
+        HostId = hostId;
+        MenuId = menuId;
+        Name = name;
+        Description = description;
+        StartDateTime = startDateTime;
+        EndDateTime = endDateTime;
+    }
+
+    public HostId GetResourceId() => HostId;
+
+    public IResult Authorize(Actor actor, Host host) =>
+        host.OwnerId.Value == actor.Id.Value
+            ? Result.Ok()
+            : Result.Fail(new Error.Forbidden("dinners.owner", ResourceRef.For<Host>(HostId)));
+}

--- a/Application/src/Dinners/Commands/ScheduleDinnerCommandHandler.cs
+++ b/Application/src/Dinners/Commands/ScheduleDinnerCommandHandler.cs
@@ -1,0 +1,58 @@
+namespace BuberDinner.Application.Dinners.Commands;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.Dinner.Entities;
+using BuberDinner.Domain.Menu;
+using Mediator;
+
+/// <summary>
+/// Handles <see cref="ScheduleDinnerCommand"/>: validates that the chosen <c>MenuId</c>
+/// belongs to the route <c>HostId</c>, builds the aggregate via <see cref="Dinner.TryCreate"/>,
+/// persists it, and lets <c>DomainEventDispatchBehavior</c> publish the
+/// <c>DinnerScheduled</c> event after the handler returns.
+/// </summary>
+public sealed class ScheduleDinnerCommandHandler : ICommandHandler<ScheduleDinnerCommand, Result<Dinner>>
+{
+    private readonly IRepository<Dinner> _dinnerRepository;
+    private readonly IRepository<Menu> _menuRepository;
+    private readonly TimeProvider _clock;
+
+    public ScheduleDinnerCommandHandler(
+        IRepository<Dinner> dinnerRepository,
+        IRepository<Menu> menuRepository,
+        TimeProvider clock)
+    {
+        _dinnerRepository = dinnerRepository;
+        _menuRepository = menuRepository;
+        _clock = clock;
+    }
+
+    public async ValueTask<Result<Dinner>> Handle(ScheduleDinnerCommand request, CancellationToken cancellationToken)
+    {
+        // Resource auth proves the caller owns the route Host. It does NOT prove the supplied
+        // MenuId exists or belongs to that host. Without this load, a host could schedule a
+        // dinner against another host's menu (cookbook Recipe 22 — fail-loud on missing related
+        // aggregates).
+        var menu = await _menuRepository.FindById(request.MenuId.Value.ToString(), cancellationToken);
+        if (menu is null || menu.HostId != request.HostId)
+            return Result.Fail<Dinner>(new Error.NotFound(ResourceRef.For<Menu>(request.MenuId))
+            {
+                Detail = "Menu does not belong to the specified host.",
+            });
+
+        var dinnerResult = Dinner.TryCreate(
+            request.Name, request.Description,
+            request.HostId, request.MenuId,
+            request.StartDateTime, request.EndDateTime,
+            _clock);
+        if (dinnerResult.IsFailure)
+            return dinnerResult;
+        var dinner = dinnerResult.GetValueOrThrow("dinner");
+
+        await _dinnerRepository.Add(dinner, cancellationToken);
+        return Result.Ok(dinner);
+    }
+}

--- a/Application/src/Dinners/Events/DinnerEventHandlers.cs
+++ b/Application/src/Dinners/Events/DinnerEventHandlers.cs
@@ -1,0 +1,90 @@
+namespace BuberDinner.Application.Dinners.Events;
+
+using System.Threading;
+using System.Threading.Tasks;
+using BuberDinner.Domain.Dinner.Events;
+using Trellis.Mediator;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Side-effect-only handler that logs <see cref="DinnerScheduled"/> events. The real-world
+/// equivalent would publish to an outbox, notify guests, etc. — kept as a log line so the
+/// showcase demonstrates the pipeline wiring without dragging in a notification stack.
+/// </summary>
+public sealed class LogDinnerScheduledHandler : IDomainEventHandler<DinnerScheduled>
+{
+    private readonly ILogger<LogDinnerScheduledHandler> _logger;
+
+    public LogDinnerScheduledHandler(ILogger<LogDinnerScheduledHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public ValueTask HandleAsync(DinnerScheduled notification, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Dinner {DinnerId} scheduled for host {HostId} from {StartDateTime:o} to {EndDateTime:o}",
+            notification.DinnerId.Value, notification.HostId.Value,
+            notification.StartDateTime, notification.EndDateTime);
+        return ValueTask.CompletedTask;
+    }
+}
+
+/// <summary>Logs <see cref="DinnerStarted"/> events.</summary>
+public sealed class LogDinnerStartedHandler : IDomainEventHandler<DinnerStarted>
+{
+    private readonly ILogger<LogDinnerStartedHandler> _logger;
+
+    public LogDinnerStartedHandler(ILogger<LogDinnerStartedHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public ValueTask HandleAsync(DinnerStarted notification, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Dinner {DinnerId} started at {OccurredAt:o}",
+            notification.DinnerId.Value, notification.OccurredAt);
+        return ValueTask.CompletedTask;
+    }
+}
+
+/// <summary>Logs <see cref="DinnerEnded"/> events.</summary>
+public sealed class LogDinnerEndedHandler : IDomainEventHandler<DinnerEnded>
+{
+    private readonly ILogger<LogDinnerEndedHandler> _logger;
+
+    public LogDinnerEndedHandler(ILogger<LogDinnerEndedHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public ValueTask HandleAsync(DinnerEnded notification, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Dinner {DinnerId} ended at {OccurredAt:o}",
+            notification.DinnerId.Value, notification.OccurredAt);
+        return ValueTask.CompletedTask;
+    }
+}
+
+/// <summary>Logs <see cref="DinnerCancelled"/> events, including the host-supplied reason.</summary>
+public sealed class LogDinnerCancelledHandler : IDomainEventHandler<DinnerCancelled>
+{
+    private readonly ILogger<LogDinnerCancelledHandler> _logger;
+
+    public LogDinnerCancelledHandler(ILogger<LogDinnerCancelledHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public ValueTask HandleAsync(DinnerCancelled notification, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Dinner {DinnerId} cancelled at {OccurredAt:o} — reason: {Reason}",
+            notification.DinnerId.Value, notification.OccurredAt, notification.Reason);
+        return ValueTask.CompletedTask;
+    }
+}
+
+

--- a/Application/src/Dinners/Queries/GetDinnerQuery.cs
+++ b/Application/src/Dinners/Queries/GetDinnerQuery.cs
@@ -1,0 +1,44 @@
+namespace BuberDinner.Application.Dinners.Queries;
+
+using System.Threading;
+using System.Threading.Tasks;
+using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.Dinner.Entities;
+using BuberDinner.Domain.Dinner.ValueObject;
+using BuberDinner.Domain.Host.ValueObject;
+using Mediator;
+
+public sealed class GetDinnerQuery : IRequest<Result<Dinner>>
+{
+    public HostId HostId { get; }
+    public DinnerId DinnerId { get; }
+
+    public GetDinnerQuery(HostId hostId, DinnerId dinnerId)
+    {
+        HostId = hostId;
+        DinnerId = dinnerId;
+    }
+}
+
+public sealed class GetDinnerQueryHandler : IRequestHandler<GetDinnerQuery, Result<Dinner>>
+{
+    private readonly IRepository<Dinner> _repo;
+
+    public GetDinnerQueryHandler(IRepository<Dinner> repo)
+    {
+        _repo = repo;
+    }
+
+    public async ValueTask<Result<Dinner>> Handle(GetDinnerQuery request, CancellationToken cancellationToken)
+    {
+        var dinner = await _repo.FindById(request.DinnerId.Value.ToString(), cancellationToken);
+        if (dinner is null)
+            return Result.Fail<Dinner>(new Error.NotFound(ResourceRef.For<Dinner>(request.DinnerId)));
+        if (dinner.HostId != request.HostId)
+            return Result.Fail<Dinner>(new Error.NotFound(ResourceRef.For<Dinner>(request.DinnerId))
+            {
+                Detail = "Dinner does not belong to the specified host.",
+            });
+        return Result.Ok(dinner);
+    }
+}

--- a/Application/src/Dinners/Queries/ListDinnersForHostQuery.cs
+++ b/Application/src/Dinners/Queries/ListDinnersForHostQuery.cs
@@ -1,0 +1,41 @@
+namespace BuberDinner.Application.Dinners.Queries;
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.Dinner.Entities;
+using BuberDinner.Domain.Host.ValueObject;
+using Mediator;
+
+/// <summary>
+/// Lists all dinners owned by the supplied <see cref="HostId"/>. Simple (non-paginated)
+/// for PR 2 — full <c>Page&lt;T&gt;</c> + <c>Cursor</c> pagination lands in PR 3.
+/// </summary>
+public sealed class ListDinnersForHostQuery : IRequest<Result<IReadOnlyList<Dinner>>>
+{
+    public HostId HostId { get; }
+
+    public ListDinnersForHostQuery(HostId hostId)
+    {
+        HostId = hostId;
+    }
+}
+
+public sealed class ListDinnersForHostQueryHandler
+    : IRequestHandler<ListDinnersForHostQuery, Result<IReadOnlyList<Dinner>>>
+{
+    private readonly IDinnerRepository _repo;
+
+    public ListDinnersForHostQueryHandler(IDinnerRepository repo)
+    {
+        _repo = repo;
+    }
+
+    public ValueTask<Result<IReadOnlyList<Dinner>>> Handle(
+        ListDinnersForHostQuery request, CancellationToken cancellationToken)
+    {
+        IReadOnlyList<Dinner> dinners = _repo.GetForHost(request.HostId);
+        return ValueTask.FromResult(Result.Ok(dinners));
+    }
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,6 +29,9 @@
     <PackageVersion Include="Trellis.Http.Abstractions" Version="$(TrellisVersion)" />
     <PackageVersion Include="Trellis.Mediator" Version="$(TrellisVersion)" />
     <PackageVersion Include="Trellis.Primitives" Version="$(TrellisVersion)" />
+    <PackageVersion Include="Trellis.StateMachine" Version="$(TrellisVersion)" />
+    <PackageVersion Include="Stateless" Version="5.20.1" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
   </ItemGroup>
   <!-- Test -->
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,12 +31,12 @@
     <PackageVersion Include="Trellis.Primitives" Version="$(TrellisVersion)" />
     <PackageVersion Include="Trellis.StateMachine" Version="$(TrellisVersion)" />
     <PackageVersion Include="Stateless" Version="5.20.1" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
   </ItemGroup>
   <!-- Test -->
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="xunit" Version="2.8.0" />
     <PackageVersion Include="Xunit.DependencyInjection" Version="9.3.0" />

--- a/Docs/DomainModels/Aggregates.Dinner.md
+++ b/Docs/DomainModels/Aggregates.Dinner.md
@@ -2,51 +2,63 @@
 
 ## Dinner
 
-```csharp
-class Dinner
-{
-    // TODO: Add methods
-}
+Lifecycle-driven aggregate. State transitions enforced via a Stateless state machine
+configured inside the aggregate; transitions return `Result<Dinner>` so the handler
+chain composes cleanly. Every successful transition adds one entry to
+`DomainEvents`, dispatched by `DomainEventDispatchBehavior` after the handler returns
+success — registered handlers fire post-persistence.
+
+### Status
+
+```text
+Upcoming ──Start──▶ InProgress ──End──▶ Ended    (terminal)
+   │
+   └──────Cancel(reason)──▶ Cancelled            (terminal)
 ```
+
+`Ended` and `Cancelled` are both terminal but semantically distinct:
+
+- `Cancelled` = the dinner *never happened*. Set from `Upcoming` only.
+- `Ended` = the dinner *ran to completion*. Set from `InProgress` only.
+
+### Domain events
+
+| Event | When | Payload |
+|---|---|---|
+| `DinnerScheduled` | `TryCreate` succeeds | `DinnerId, HostId, MenuId, StartDateTime, EndDateTime, OccurredAt` |
+| `DinnerStarted`   | `Start(clock)` succeeds | `DinnerId, HostId, MenuId, OccurredAt` |
+| `DinnerEnded`     | `End(clock)` succeeds | `DinnerId, HostId, MenuId, OccurredAt` |
+| `DinnerCancelled` | `Cancel(reason, clock)` succeeds | `DinnerId, HostId, MenuId, Reason, OccurredAt` |
+
+Per cookbook Recipe 17: `OccurredAt` is the *only* timestamp on a domain event; the
+event type name carries the semantic. Don't add `StartedAt`/`EndedAt`/`CancelledAt`
+aliases to the events — those live on the aggregate.
+
+### Wire shape
 
 ```json
 {
-    "id": { "value": "00000000-0000-0000-0000-000000000000" },
-    "name": "Yummy Dinner",
-    "description": "A dinner with yummy food",
-    "startDateTime": "2020-01-01T00:00:00.0000000Z",
-    "endDateTime": "2020-01-01T00:00:00.0000000Z",
-    "startedDateTime": null,
-    "endedDateTime": null,
-    "status": "Upcoming", // Upcoming, InProgress, Ended, Cancelled
-    "isPublic": true,
-    "maxGuests": 10,
-    "price": {
-        "amount": 10.99,
-        "currency": "USD"
-    },
-    "hostId": { "value": "00000000-0000-0000-0000-000000000000" },
-    "menuId": { "value": "00000000-0000-0000-0000-000000000000" },
-    "imageUrl": "https://image.com",
-    "location": {
-        "name": "Dan's Pizza Place",
-        "address": "Berlin, Germany",
-        "latitude": 52.520008,
-        "longitude": 13.404954
-    },
-    "reservations": [
-        {
-            "id": { "value": "00000000-0000-0000-0000-000000000000" },
-            "guestCount": 2,
-            "reservationStatus": "Reserved", // PendingGuestConfirmation, Reserved, Cancelled
-            "guestId": { "value": "00000000-0000-0000-0000-000000000000" },
-            "billId": { "value": "00000000-0000-0000-0000-000000000000 }",
-            "arrivalDateTime": null,
-            "createdDateTime": "2020-01-01T00:00:00.0000000Z",
-            "updatedDateTime": "2020-01-01T00:00:00.0000000Z"
-        }
-    ],
-    "createdDateTime": "2020-01-01T00:00:00.0000000Z",
-    "updatedDateTime": "2020-01-01T00:00:00.0000000Z"
+    "id": "019e95a2-5735-71c1-a435-f78c5c2d6182",
+    "name": "Brunch with friends",
+    "description": "Casual Sunday brunch",
+    "hostId": "019e95a2-5601-7868-9d20-7fb072bd5757",
+    "menuId": "019e95a2-567e-739e-a05e-fe55ca12e19e",
+    "status": "Upcoming",
+    "startDateTime": "2026-07-01T18:00:00+00:00",
+    "endDateTime":   "2026-07-01T21:00:00+00:00",
+    "startedAt": null,
+    "endedAt": null,
+    "cancelledAt": null,
+    "cancellationReason": null
 }
 ```
+
+### Reservations / Location / Price (deferred)
+
+The earlier aspirational shape included `reservations[]`, `location`, `price`, and
+`imageUrl`. Those land in later PRs:
+
+- **PR 4**: `Reservation` entities under Dinner + `Bookings` aggregate + idempotency-key
+  bookings + multi-aggregate orchestration.
+- **PR 5+**: `Location` value object (composite), `Money` from `Trellis.Primitives`, optional
+  image URL with `Maybe<UrlValue>` per Recipe 14.

--- a/Docs/PR2_DINNER_STATE_MACHINE.md
+++ b/Docs/PR2_DINNER_STATE_MACHINE.md
@@ -1,0 +1,212 @@
+# PR 2 — Dinner state machine + domain events
+
+> *Showcase: how a real BuberDinner aggregate composes Trellis's `LazyStateMachine<,>`,
+> the `ICommand<TAggregate>` + `DomainEventDispatchBehavior` wiring, and the existing
+> resource-authorization plumbing — without leaking any state-machine internals to
+> handler or controller code.*
+
+---
+
+## What this PR adds (at a glance)
+
+| Capability | Where | Cookbook |
+|---|---|---|
+| `Dinner` aggregate with state machine | `Domain/src/Dinner/Entities/Dinner.cs` | Recipe 9 |
+| `DinnerStatus` / `DinnerTrigger` as `RequiredEnum<TSelf>` | `Domain/src/Dinner/ValueObjects/` | Recipe 9 |
+| 4 domain events, `OccurredAt` only | `Domain/src/Dinner/Events/DinnerEvents.cs` | Recipe 17 |
+| `POST /hosts/{hostId}/dinners` — schedule + validates Menu ownership | `DinnersController.ScheduleDinner` | n/a |
+| `GET /hosts/{hostId}/dinners/{dinnerId}` with strong ETag | `DinnersController.GetDinner` | Recipe 6 |
+| `GET /hosts/{hostId}/dinners` — list (paginated in PR 3) | `DinnersController.ListDinners` | (Recipe 3 coming) |
+| `POST .../start` `/end` `/cancel` — state transitions, body-less per Recipe 23 | `DinnersController` | Recipe 23 |
+| Resource auth on every dinner mutation (`dinners.owner`) | `*Command : IAuthorizeResource<Host>` | Recipe 7 |
+| Per-handler `IDomainEventHandler<TEvent>` registration | `Api/src/DependencyInjection.cs` | Mediator §547 |
+| `TimeProvider.System` injection | DI + `Dinner.TryCreate(..., TimeProvider clock)` | Recipe 17 §1319 |
+| `Trellis.StateMachine` + `Stateless` packages | `Directory.Packages.props`, `Domain.csproj` | Recipe 9 |
+
+## The state machine (entire configuration in 9 lines)
+
+```csharp
+private static void ConfigureMachine(StateMachine<DinnerStatus, DinnerTrigger> machine)
+{
+    machine.Configure(DinnerStatus.Upcoming)
+           .Permit(DinnerTrigger.Start,  DinnerStatus.InProgress)
+           .Permit(DinnerTrigger.Cancel, DinnerStatus.Cancelled);
+
+    machine.Configure(DinnerStatus.InProgress)
+           .Permit(DinnerTrigger.End,    DinnerStatus.Ended);
+
+    // Ended and Cancelled are terminal — no transitions configured.
+}
+```
+
+The aggregate holds a `LazyStateMachine<DinnerStatus, DinnerTrigger>` field that defers
+construction until first `FireResult(...)`, accesses `Status` through the supplied
+getter, and writes the new state through the supplied setter:
+
+```csharp
+_machine = new LazyStateMachine<DinnerStatus, DinnerTrigger>(
+    stateAccessor: () => Status,
+    stateMutator: s => Status = s,
+    configure: ConfigureMachine);
+
+public Result<Dinner> Start(TimeProvider clock) =>
+    _machine.FireResult(DinnerTrigger.Start)
+        .Map(_ =>
+        {
+            var occurredAt = clock.GetUtcNow();
+            StartedAt = occurredAt;
+            DomainEvents.Add(new DinnerStarted(Id, HostId, MenuId, occurredAt));
+            return this;
+        });
+```
+
+An invalid trigger short-circuits to `Error.InvalidInput` with reason code
+`state.machine.invalid.transition` — HTTP 422 at the boundary, with a typed rule
+violation a caller can pattern-match on. No exception parsing, no string sniffing.
+
+## The wire dump (verified end-to-end)
+
+```http
+# 1. Schedule a dinner → 201 + ETag + Location, status = "Upcoming".
+HTTP/1.1 201 Created
+ETag: "d14d94c7c9b64426ae88d5be7a5bcde6"
+Location: /hosts/.../dinners/019e95a2-5735-71c1-a435-f78c5c2d6182
+{ "status": "Upcoming", "startedAt": null, "endedAt": null, "cancelledAt": null, ... }
+
+# 2. POST .../start → 200, status = "InProgress", startedAt populated.
+HTTP/1.1 200 OK
+ETag: "<new>"
+{ "status": "InProgress", "startedAt": "2026-06-05T02:35:16.010Z", ... }
+
+# 3. POST .../start AGAIN → 422 with state.machine.invalid.transition.
+HTTP/1.1 422 Unprocessable Entity
+Content-Type: application/problem+json
+{ "status": 422, "code": "invalid-input",
+  "rules": [{ "code": "state.machine.invalid.transition",
+              "detail": "Trigger 'Start' is not permitted from state 'InProgress'." }] }
+
+# 4. POST .../end → 200, status = "Ended", endedAt populated.
+HTTP/1.1 200 OK
+{ "status": "Ended", "startedAt": "...", "endedAt": "2026-06-05T02:35:24.227Z" }
+
+# 5. Cancel from Upcoming → 200, status = "Cancelled", cancelledAt set, endedAt STILL null.
+HTTP/1.1 200 OK
+{ "status": "Cancelled",
+  "cancelledAt": "2026-06-05T02:35:48.949Z",
+  "cancellationReason": "host illness",
+  "startedAt": null, "endedAt": null }
+
+# 6. Cancel from InProgress → 422.
+HTTP/1.1 422 Unprocessable Entity
+{ rules: [{ code: "state.machine.invalid.transition",
+            detail: "Trigger 'Cancel' is not permitted from state 'InProgress'." }] }
+
+# 7. Start as a different user → 403 Forbidden via IAuthorizeResource<Host>.
+HTTP/1.1 403 Forbidden
+{ "status": 403, "code": "dinners.owner", "kind": "forbidden" }
+
+# 8. Schedule with a menu owned by a different host → 404.
+HTTP/1.1 404 Not Found
+{ "status": 404, "detail": "Menu does not belong to the specified host.", ... }
+
+# 9. Server log (every successful transition fires one IDomainEventHandler<TEvent>):
+info: LogDinnerScheduledHandler[0] Dinner X scheduled for host Y from … to …
+info: LogDinnerStartedHandler[0]   Dinner X started at 2026-06-05T02:35:16Z
+info: LogDinnerEndedHandler[0]     Dinner X ended at 2026-06-05T02:35:24Z
+info: LogDinnerCancelledHandler[0] Dinner Z cancelled at … — reason: host illness
+```
+
+## Why `ICommand<Result<Dinner>>` (and not `IRequest<Result<Dinner>>`)
+
+The `DomainEventDispatchBehavior` constraint is *specifically* `where TMessage : ICommand<TResponse>`
+(per `trellis-api-mediator.md:677`). `IRequest` and `ICommand` are sibling interfaces in
+the Mediator package — both implement `IMessage` but neither extends the other — so a
+command marked `IRequest<Result<Dinner>>` is silently ignored by the dispatch behavior,
+and zero domain events fire. **Every BuberDinner command that returns `Result<TAggregate>`
+where `TAggregate : IAggregate` must use `ICommand<...>`.** The existing
+`CreateMenuCommand`/`UpdateMenuCommand` still use `IRequest` because they don't raise
+events; migrating them is harmless follow-on work.
+
+## Why the dispatch behavior fires AFTER the handler writes
+
+`DomainEventDispatchBehavior` snapshots `aggregate.UncommittedEvents()` after the inner
+pipeline returns success, dispatches that snapshot to every registered
+`IDomainEventHandler<TEvent>`, then calls `aggregate.AcceptChanges()` if dispatch is
+clean. So handlers observe COMMITTED state — they never see a transient mutation that the
+repository never persisted. For the in-memory repository the distinction is academic, but
+when this same code runs against EF Core with `TransactionalCommandBehavior` registered
+innermost, dispatch fires AFTER the transaction commits and a cascade exception cannot
+roll back the database write.
+
+## Why per-handler registration over assembly scanning
+
+```csharp
+services.AddDomainEventDispatch();
+services.AddDomainEventHandler<DinnerScheduled, LogDinnerScheduledHandler>();
+services.AddDomainEventHandler<DinnerStarted,   LogDinnerStartedHandler>();
+services.AddDomainEventHandler<DinnerEnded,     LogDinnerEndedHandler>();
+services.AddDomainEventHandler<DinnerCancelled, LogDinnerCancelledHandler>();
+```
+
+Per-handler registration is AOT-safe (no `RequiresUnreferencedCode` warning), idempotent,
+and — most importantly — makes wire-up intent obvious at the registration site. Future
+readers can grep `AddDomainEventHandler` once and see every event/handler pair the
+service publishes; assembly scanning hides that contract.
+
+## Why `Cancelled` and `Ended` are kept distinct (not collapsed to `Ended` + reason)
+
+| Status | Semantic | When | Persisted timestamps |
+|---|---|---|---|
+| `Cancelled` | The dinner **never happened**. | `Cancel(reason)` from `Upcoming` only | `CancelledAt`, `CancellationReason`; `EndedAt` stays null |
+| `Ended` | The dinner **ran to completion** (possibly early). | `End()` from `InProgress` | `StartedAt`, `EndedAt` |
+
+This matters downstream. Refund/no-show logic answers "did the event happen?", calendars
+filter past events on `EndedAt`, audit reports differentiate "host called it off" from
+"event ran". Overloading `Ended` with an optional `CancellationReason` would force every
+consumer to know the convention; explicit separation keeps the semantic on the type.
+
+If we want "host called the event off after it started" later, the right answer is a
+separate `EndEarly(reason)` transition that goes `InProgress → EndedEarly` (a fifth
+status), not "make `Cancel` valid from `InProgress`".
+
+## Validation gates (request → command → aggregate)
+
+1. **Route binding** — `:HostId` and `:DinnerId` route constraints (Trellis.Asp.Routing)
+   reject non-GUID paths at routing time (404 before the controller runs).
+2. **Request DTO** — `ScheduleDinnerRequest.ToScheduleDinnerCommand` parses primitives
+   into typed VOs via `Name.TryCreate`, `Description.TryCreate`, `MenuId.TryCreate`. Any
+   parse failure is `Error.InvalidInput` (422) with field-bound violations.
+3. **Resource auth** — `IAuthorizeResource<Host>` loads the route Host and verifies the
+   actor owns it. Failure: 403 with `code: "dinners.owner"`.
+4. **Handler-side referential integrity** — `ScheduleDinnerCommandHandler` loads the
+   supplied `MenuId` and rejects if `Menu.HostId != request.HostId`. Failure: 404.
+5. **Aggregate invariants** — `Dinner.TryCreate` rejects `EndDateTime <= StartDateTime`
+   (422) and runs the FluentValidation rule set; `Cancel(reason)` rejects blank reasons
+   before consulting the state machine.
+6. **State machine** — `FireResult(trigger)` rejects invalid transitions (422 with
+   `state.machine.invalid.transition`).
+
+## Files that show off the most
+
+| File | Why look here |
+|---|---|
+| `Domain/src/Dinner/Entities/Dinner.cs` | The whole state machine in one file — config helper, transition methods, event emission |
+| `Application/src/Dinners/Commands/ScheduleDinnerCommand.cs` | `ICommand<Result<Dinner>>` + `IAuthorizeResource<Host>` on one record |
+| `Application/src/Dinners/Commands/ScheduleDinnerCommandHandler.cs` | Cross-aggregate referential check (Recipe 22 in miniature) before constructing the aggregate |
+| `Application/src/Dinners/Events/DinnerEventHandlers.cs` | Four `IDomainEventHandler<TEvent>` impls — log-only, idempotent, side-effect-only |
+| `Api/src/2022-12-21/Controllers/DinnersController.cs` | Body-less state-transition POSTs with no `[Consumes("application/json")]` on `/start` and `/end` |
+| `Api/src/DependencyInjection.cs` | `AddDomainEventDispatch()` + 4 `AddDomainEventHandler<,>` lines + `AddSingleton(TimeProvider.System)` |
+| `Api/tests/2022-12-21/DinnerStateMachineTests.cs` | Per-test `CapturedEvents` sink validates events were published with the right `OccurredAt` |
+
+## Stop-gaps and follow-ons
+
+- **In-memory Dinner repository** falls back from the Cosmos branch via `AddCosmosDb`
+  too — same pattern as `Host` (PR 1, Cosmos DI gap fix). Marked `// TODO: replace with
+  DinnerCosmosDbRepository when implemented`.
+- **List endpoint** is a simple non-paginated array today. PR 3 will swap this for
+  `Page<Dinner>` + `Cursor` per Recipe 3.
+- **Domain event handlers** are log-only. PR 4 (Bookings + outbox + reservations) will
+  add a real `DinnerScheduledIntegrationEventPublisher` that pushes guest notifications.
+- Trellis package `Trellis.StateMachine` does not currently ship a
+  `trellis-api-statemachine.md` reference doc in the cookbook bundle (only a passing
+  `[see also]` link). Acknowledged; not blocking for PR 2.

--- a/Domain/src/BuberDinner.Domain.csproj
+++ b/Domain/src/BuberDinner.Domain.csproj
@@ -3,5 +3,7 @@
       <PackageReference Include="Trellis.Core" />
       <PackageReference Include="Trellis.Primitives" />
       <PackageReference Include="Trellis.FluentValidation" />
+      <PackageReference Include="Trellis.StateMachine" />
+      <PackageReference Include="Stateless" />
    </ItemGroup>
 </Project>

--- a/Domain/src/Dinner/Entities/Dinner.cs
+++ b/Domain/src/Dinner/Entities/Dinner.cs
@@ -1,0 +1,179 @@
+namespace BuberDinner.Domain.Dinner.Entities;
+
+using System;
+using BuberDinner.Domain.Common.ValueObjects;
+using BuberDinner.Domain.Dinner.Events;
+using BuberDinner.Domain.Dinner.ValueObject;
+using BuberDinner.Domain.Host.ValueObject;
+using BuberDinner.Domain.Menu.ValueObject;
+using FluentValidation;
+using Stateless;
+using Trellis.StateMachine;
+
+/// <summary>
+/// A dinner is a scheduled meal hosted by a <see cref="Host"/>, drawn from a particular
+/// <see cref="Menu"/>. Its lifecycle is driven by a Stateless state machine (Cookbook
+/// Recipe 9) wired through <see cref="LazyStateMachine{TState, TTrigger}"/>, with one
+/// domain event raised per successful transition (Cookbook Recipe 17).
+/// </summary>
+public sealed class Dinner : Aggregate<DinnerId>
+{
+    public Name Name { get; }
+    public Description Description { get; }
+    public HostId HostId { get; }
+    public MenuId MenuId { get; }
+    public DateTimeOffset StartDateTime { get; }
+    public DateTimeOffset EndDateTime { get; }
+    public DinnerStatus Status { get; private set; }
+
+    /// <summary>Wall-clock instant at which <see cref="Start"/> succeeded. Null until then.</summary>
+    public DateTimeOffset? StartedAt { get; private set; }
+
+    /// <summary>Wall-clock instant at which <see cref="End"/> succeeded. Null until then.</summary>
+    public DateTimeOffset? EndedAt { get; private set; }
+
+    /// <summary>
+    /// Wall-clock instant at which <see cref="Cancel"/> succeeded. Distinct from
+    /// <see cref="EndedAt"/> so consumers can tell "the dinner ran" from "the dinner was
+    /// called off". Null unless the dinner was cancelled.
+    /// </summary>
+    public DateTimeOffset? CancelledAt { get; private set; }
+
+    /// <summary>Reason supplied to <see cref="Cancel"/>. Null unless the dinner was cancelled.</summary>
+    public string? CancellationReason { get; private set; }
+
+    private readonly LazyStateMachine<DinnerStatus, DinnerTrigger> _machine;
+
+    /// <summary>
+    /// Schedules a new dinner. Returns a validated <see cref="Result{Dinner}"/> in the
+    /// <see cref="DinnerStatus.Upcoming"/> state, with a <see cref="DinnerScheduled"/>
+    /// domain event already queued for dispatch.
+    /// </summary>
+    public static Result<Dinner> TryCreate(
+        Name name,
+        Description description,
+        HostId hostId,
+        MenuId menuId,
+        DateTimeOffset startDateTime,
+        DateTimeOffset endDateTime,
+        TimeProvider clock)
+    {
+        if (endDateTime <= startDateTime)
+            return Result.Fail<Dinner>(
+                Error.InvalidInput.ForField(nameof(EndDateTime), "dinner.invalid.schedule",
+                    "EndDateTime must be strictly after StartDateTime."));
+
+        var dinner = new Dinner(
+            DinnerId.NewUniqueV7(), name, description, hostId, menuId, startDateTime, endDateTime);
+        var validation = s_validator.ValidateToResult(dinner);
+        if (validation.IsFailure)
+            return validation;
+
+        dinner.DomainEvents.Add(new DinnerScheduled(
+            dinner.Id, dinner.HostId, dinner.MenuId,
+            dinner.StartDateTime, dinner.EndDateTime, clock.GetUtcNow()));
+        return Result.Ok(dinner);
+    }
+
+    private Dinner(
+        DinnerId id,
+        Name name,
+        Description description,
+        HostId hostId,
+        MenuId menuId,
+        DateTimeOffset startDateTime,
+        DateTimeOffset endDateTime)
+        : base(id)
+    {
+        Name = name;
+        Description = description;
+        HostId = hostId;
+        MenuId = menuId;
+        StartDateTime = startDateTime;
+        EndDateTime = endDateTime;
+        Status = DinnerStatus.Upcoming;
+
+        _machine = new LazyStateMachine<DinnerStatus, DinnerTrigger>(
+            stateAccessor: () => Status,
+            stateMutator: s => Status = s,
+            configure: ConfigureMachine);
+    }
+
+    /// <summary>
+    /// Transitions the dinner from <see cref="DinnerStatus.Upcoming"/> to
+    /// <see cref="DinnerStatus.InProgress"/>, sets <see cref="StartedAt"/>, and raises
+    /// <see cref="DinnerStarted"/>. Returns <see cref="Error.InvalidInput"/> with reason
+    /// code <c>state.machine.invalid.transition</c> (HTTP 422) when the current state
+    /// does not permit the transition.
+    /// </summary>
+    public Result<Dinner> Start(TimeProvider clock) =>
+        _machine.FireResult(DinnerTrigger.Start)
+            .Map(_ =>
+            {
+                var occurredAt = clock.GetUtcNow();
+                StartedAt = occurredAt;
+                DomainEvents.Add(new DinnerStarted(Id, HostId, MenuId, occurredAt));
+                return this;
+            });
+
+    /// <summary>
+    /// Transitions the dinner from <see cref="DinnerStatus.InProgress"/> to
+    /// <see cref="DinnerStatus.Ended"/>, sets <see cref="EndedAt"/>, and raises
+    /// <see cref="DinnerEnded"/>.
+    /// </summary>
+    public Result<Dinner> End(TimeProvider clock) =>
+        _machine.FireResult(DinnerTrigger.End)
+            .Map(_ =>
+            {
+                var occurredAt = clock.GetUtcNow();
+                EndedAt = occurredAt;
+                DomainEvents.Add(new DinnerEnded(Id, HostId, MenuId, occurredAt));
+                return this;
+            });
+
+    /// <summary>
+    /// Transitions the dinner from <see cref="DinnerStatus.Upcoming"/> to
+    /// <see cref="DinnerStatus.Cancelled"/>, records the supplied <paramref name="reason"/>,
+    /// sets <see cref="CancelledAt"/>, and raises <see cref="DinnerCancelled"/>. Not
+    /// permitted once the dinner has started.
+    /// </summary>
+    public Result<Dinner> Cancel(string reason, TimeProvider clock)
+    {
+        if (string.IsNullOrWhiteSpace(reason))
+            return Result.Fail<Dinner>(
+                Error.InvalidInput.ForField(nameof(reason), "dinner.cancel.reason-required",
+                    "Cancellation reason must not be blank."));
+
+        return _machine.FireResult(DinnerTrigger.Cancel)
+            .Map(_ =>
+            {
+                var occurredAt = clock.GetUtcNow();
+                CancelledAt = occurredAt;
+                CancellationReason = reason;
+                DomainEvents.Add(new DinnerCancelled(Id, HostId, MenuId, reason, occurredAt));
+                return this;
+            });
+    }
+
+    private static void ConfigureMachine(StateMachine<DinnerStatus, DinnerTrigger> machine)
+    {
+        machine.Configure(DinnerStatus.Upcoming)
+               .Permit(DinnerTrigger.Start, DinnerStatus.InProgress)
+               .Permit(DinnerTrigger.Cancel, DinnerStatus.Cancelled);
+
+        machine.Configure(DinnerStatus.InProgress)
+               .Permit(DinnerTrigger.End, DinnerStatus.Ended);
+
+        // Ended and Cancelled are terminal — no transitions configured.
+    }
+
+    static readonly InlineValidator<Dinner> s_validator = new()
+    {
+        v => v.RuleFor(x => x.Id).NotEmpty(),
+        v => v.RuleFor(x => x.Name).NotEmpty(),
+        v => v.RuleFor(x => x.Description).NotEmpty(),
+        v => v.RuleFor(x => x.HostId).NotEmpty(),
+        v => v.RuleFor(x => x.MenuId).NotEmpty(),
+        v => v.RuleFor(x => x.Status).NotEmpty(),
+    };
+}

--- a/Domain/src/Dinner/Entities/Dinner.cs
+++ b/Domain/src/Dinner/Entities/Dinner.cs
@@ -58,6 +58,17 @@ public sealed class Dinner : Aggregate<DinnerId>
         DateTimeOffset endDateTime,
         TimeProvider clock)
     {
+        // Reject default(DateTimeOffset) (year 0001) so an omitted-in-JSON property doesn't
+        // silently produce an aggregate scheduled at 0001-01-01 that still satisfies the
+        // EndDateTime > StartDateTime relative check below.
+        if (startDateTime == default)
+            return Result.Fail<Dinner>(
+                Error.InvalidInput.ForField(nameof(StartDateTime), "dinner.invalid.start-required",
+                    "StartDateTime is required."));
+        if (endDateTime == default)
+            return Result.Fail<Dinner>(
+                Error.InvalidInput.ForField(nameof(EndDateTime), "dinner.invalid.end-required",
+                    "EndDateTime is required."));
         if (endDateTime <= startDateTime)
             return Result.Fail<Dinner>(
                 Error.InvalidInput.ForField(nameof(EndDateTime), "dinner.invalid.schedule",

--- a/Domain/src/Dinner/Events/DinnerEvents.cs
+++ b/Domain/src/Dinner/Events/DinnerEvents.cs
@@ -1,0 +1,42 @@
+namespace BuberDinner.Domain.Dinner.Events;
+
+using BuberDinner.Domain.Dinner.ValueObject;
+using BuberDinner.Domain.Host.ValueObject;
+using BuberDinner.Domain.Menu.ValueObject;
+
+/// <summary>
+/// Raised when a host schedules a new dinner. Per Cookbook Recipe 17, <see cref="OccurredAt"/>
+/// is the only timestamp; the event-type name carries the "scheduled" semantic.
+/// </summary>
+public sealed record DinnerScheduled(
+    DinnerId DinnerId,
+    HostId HostId,
+    MenuId MenuId,
+    DateTimeOffset StartDateTime,
+    DateTimeOffset EndDateTime,
+    DateTimeOffset OccurredAt) : IDomainEvent;
+
+/// <summary>Raised when a scheduled dinner transitions from <c>Upcoming</c> to <c>InProgress</c>.</summary>
+public sealed record DinnerStarted(
+    DinnerId DinnerId,
+    HostId HostId,
+    MenuId MenuId,
+    DateTimeOffset OccurredAt) : IDomainEvent;
+
+/// <summary>Raised when a running dinner transitions from <c>InProgress</c> to <c>Ended</c>.</summary>
+public sealed record DinnerEnded(
+    DinnerId DinnerId,
+    HostId HostId,
+    MenuId MenuId,
+    DateTimeOffset OccurredAt) : IDomainEvent;
+
+/// <summary>
+/// Raised when a scheduled dinner is called off before it begins. Carries the cancellation
+/// reason so notification consumers can include it.
+/// </summary>
+public sealed record DinnerCancelled(
+    DinnerId DinnerId,
+    HostId HostId,
+    MenuId MenuId,
+    string Reason,
+    DateTimeOffset OccurredAt) : IDomainEvent;

--- a/Domain/src/Dinner/ValueObjects/DinnerStatus.cs
+++ b/Domain/src/Dinner/ValueObjects/DinnerStatus.cs
@@ -1,0 +1,26 @@
+namespace BuberDinner.Domain.Dinner.ValueObject;
+
+/// <summary>
+/// Lifecycle state of a <see cref="Dinner"/>. Encoded as <see cref="RequiredEnum{TSelf}"/>
+/// so equality is symbolic and the value object satisfies the Stateless `TState` generic
+/// constraint per Cookbook Recipe 9.
+/// </summary>
+public partial class DinnerStatus : RequiredEnum<DinnerStatus>
+{
+    /// <summary>Scheduled but not yet started. The only state from which <c>Start</c> or <c>Cancel</c> are permitted.</summary>
+    public static readonly DinnerStatus Upcoming = new();
+
+    /// <summary>Currently running. The only state from which <c>End</c> is permitted.</summary>
+    public static readonly DinnerStatus InProgress = new();
+
+    /// <summary>Ran to completion. Terminal — no further transitions.</summary>
+    public static readonly DinnerStatus Ended = new();
+
+    /// <summary>Called off before it began. Terminal — no further transitions.</summary>
+    /// <remarks>
+    /// `Cancelled` means "never happened". A dinner that started and then was terminated early
+    /// transitions to <see cref="Ended"/> instead, so downstream consumers (refunds, no-show
+    /// tracking, etc.) can distinguish "the event ran" from "the event was called off".
+    /// </remarks>
+    public static readonly DinnerStatus Cancelled = new();
+}

--- a/Domain/src/Dinner/ValueObjects/DinnerTrigger.cs
+++ b/Domain/src/Dinner/ValueObjects/DinnerTrigger.cs
@@ -1,0 +1,18 @@
+namespace BuberDinner.Domain.Dinner.ValueObject;
+
+/// <summary>
+/// Triggers for the <see cref="Dinner"/> state machine. Encoded as
+/// <see cref="RequiredEnum{TSelf}"/> per Cookbook Recipe 9 so equality is symbolic
+/// and Stateless's `TTrigger` generic constraint is satisfied.
+/// </summary>
+/// <remarks>
+/// Internal: callers drive transitions through the aggregate's <c>Start</c>, <c>End</c>,
+/// <c>Cancel</c> methods. Exposing triggers outside the assembly would let callers bypass
+/// the side-effect placement the cookbook is careful about.
+/// </remarks>
+internal partial class DinnerTrigger : RequiredEnum<DinnerTrigger>
+{
+    public static readonly DinnerTrigger Start = new();
+    public static readonly DinnerTrigger End = new();
+    public static readonly DinnerTrigger Cancel = new();
+}

--- a/Domain/tests/BuberDinner.Domain.Tests.csproj
+++ b/Domain/tests/BuberDinner.Domain.Tests.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\src\BuberDinner.Domain.csproj" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
   </ItemGroup>
 
 

--- a/Domain/tests/DinnerTests.cs
+++ b/Domain/tests/DinnerTests.cs
@@ -68,6 +68,45 @@ public class DinnerTests
     }
 
     [Fact]
+    public void TryCreate_rejects_default_start_date()
+    {
+        // Guards against omitted-in-JSON properties deserializing to default(DateTimeOffset).
+        // Without this guard, a Dinner could be scheduled at year 0001 because the end-after-start
+        // relative check passes when EndDateTime is in the future.
+        var clock = Clock();
+        var bad = Dinner.TryCreate(
+            Name.TryCreate("Bad").GetValueOrThrow(),
+            Description.TryCreate("Bad").GetValueOrThrow(),
+            Host, Menu,
+            startDateTime: default,
+            endDateTime: Now.AddHours(4),
+            clock);
+
+        bad.IsFailure.Should().BeTrue();
+        var error = bad.Match(_ => null!, e => e).Should().BeOfType<Error.InvalidInput>().Subject;
+        error.Fields.Items.Should().ContainSingle()
+            .Which.ReasonCode.Should().Be("dinner.invalid.start-required");
+    }
+
+    [Fact]
+    public void TryCreate_rejects_default_end_date()
+    {
+        var clock = Clock();
+        var bad = Dinner.TryCreate(
+            Name.TryCreate("Bad").GetValueOrThrow(),
+            Description.TryCreate("Bad").GetValueOrThrow(),
+            Host, Menu,
+            startDateTime: Now.AddHours(2),
+            endDateTime: default,
+            clock);
+
+        bad.IsFailure.Should().BeTrue();
+        var error = bad.Match(_ => null!, e => e).Should().BeOfType<Error.InvalidInput>().Subject;
+        error.Fields.Items.Should().ContainSingle()
+            .Which.ReasonCode.Should().Be("dinner.invalid.end-required");
+    }
+
+    [Fact]
     public void Start_succeeds_from_Upcoming_and_raises_DinnerStarted()
     {
         var clock = Clock();

--- a/Domain/tests/DinnerTests.cs
+++ b/Domain/tests/DinnerTests.cs
@@ -1,0 +1,206 @@
+namespace BuberDinner.Domain.Tests;
+
+using BuberDinner.Domain.Common.ValueObjects;
+using BuberDinner.Domain.Dinner.Entities;
+using BuberDinner.Domain.Dinner.Events;
+using BuberDinner.Domain.Dinner.ValueObject;
+using BuberDinner.Domain.Host.ValueObject;
+using BuberDinner.Domain.Menu.ValueObject;
+using Microsoft.Extensions.Time.Testing;
+
+/// <summary>
+/// Domain tests for the <see cref="Dinner"/> aggregate state machine and the four
+/// transition-driven domain events. Uses <see cref="FakeTimeProvider"/> so every event's
+/// <c>OccurredAt</c> is deterministic and can be asserted by value.
+/// </summary>
+public class DinnerTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 7, 1, 18, 30, 0, TimeSpan.Zero);
+    private static readonly HostId Host = HostId.NewUniqueV7();
+    private static readonly MenuId Menu = MenuId.NewUniqueV7();
+
+    private static FakeTimeProvider Clock(DateTimeOffset? when = null) => new(when ?? Now);
+
+    private static Dinner NewUpcoming(TimeProvider clock)
+    {
+        var dinner = Dinner.TryCreate(
+            Name.TryCreate("Brunch").GetValueOrThrow(),
+            Description.TryCreate("Sunday brunch").GetValueOrThrow(),
+            Host, Menu,
+            startDateTime: Now.AddHours(2),
+            endDateTime: Now.AddHours(4),
+            clock).GetValueOrThrow();
+        // TryCreate stamps DinnerScheduled. Tests that don't care about it can drain the buffer.
+        return dinner;
+    }
+
+    [Fact]
+    public void TryCreate_seeds_Upcoming_and_raises_DinnerScheduled()
+    {
+        var clock = Clock();
+        var dinner = NewUpcoming(clock);
+
+        dinner.Status.Should().Be(DinnerStatus.Upcoming);
+        dinner.StartedAt.Should().BeNull();
+        dinner.EndedAt.Should().BeNull();
+        dinner.CancelledAt.Should().BeNull();
+
+        var ev = dinner.UncommittedEvents().Should().ContainSingle().Which.Should().BeOfType<DinnerScheduled>().Subject;
+        ev.OccurredAt.Should().Be(Now);
+        ev.HostId.Should().Be(Host);
+        ev.MenuId.Should().Be(Menu);
+        ev.StartDateTime.Should().Be(Now.AddHours(2));
+        ev.EndDateTime.Should().Be(Now.AddHours(4));
+    }
+
+    [Fact]
+    public void TryCreate_rejects_end_before_start()
+    {
+        var clock = Clock();
+        var bad = Dinner.TryCreate(
+            Name.TryCreate("Bad").GetValueOrThrow(),
+            Description.TryCreate("Bad").GetValueOrThrow(),
+            Host, Menu,
+            startDateTime: Now.AddHours(4),
+            endDateTime: Now.AddHours(2),
+            clock);
+        bad.IsFailure.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Start_succeeds_from_Upcoming_and_raises_DinnerStarted()
+    {
+        var clock = Clock();
+        var dinner = NewUpcoming(clock);
+        dinner.AcceptChanges(); // drain DinnerScheduled
+
+        clock.Advance(TimeSpan.FromHours(2));
+        var result = dinner.Start(clock);
+
+        result.IsSuccess.Should().BeTrue();
+        dinner.Status.Should().Be(DinnerStatus.InProgress);
+        dinner.StartedAt.Should().Be(Now.AddHours(2));
+
+        var ev = dinner.UncommittedEvents().Should().ContainSingle().Which.Should().BeOfType<DinnerStarted>().Subject;
+        ev.OccurredAt.Should().Be(Now.AddHours(2));
+        ev.HostId.Should().Be(Host);
+        ev.MenuId.Should().Be(Menu);
+    }
+
+    [Fact]
+    public void End_from_Upcoming_is_rejected_with_state_machine_reason_code()
+    {
+        var clock = Clock();
+        var dinner = NewUpcoming(clock);
+
+        var result = dinner.End(clock);
+
+        result.IsFailure.Should().BeTrue();
+        var error = result.Match(_ => null!, e => e).Should().BeOfType<Error.InvalidInput>().Subject;
+        error.Rules.Items.Should().ContainSingle()
+            .Which.ReasonCode.Should().Be("state.machine.invalid.transition");
+        dinner.Status.Should().Be(DinnerStatus.Upcoming, "rejected transitions must not mutate state");
+        dinner.EndedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void End_succeeds_from_InProgress_and_raises_DinnerEnded()
+    {
+        var clock = Clock();
+        var dinner = NewUpcoming(clock);
+        dinner.Start(clock).GetValueOrThrow();
+        dinner.AcceptChanges();
+
+        clock.Advance(TimeSpan.FromHours(2));
+        var result = dinner.End(clock);
+
+        result.IsSuccess.Should().BeTrue();
+        dinner.Status.Should().Be(DinnerStatus.Ended);
+        dinner.EndedAt.Should().Be(Now.AddHours(2));
+        var ev = dinner.UncommittedEvents().Should().ContainSingle().Which.Should().BeOfType<DinnerEnded>().Subject;
+        ev.OccurredAt.Should().Be(Now.AddHours(2));
+    }
+
+    [Fact]
+    public void Cancel_succeeds_from_Upcoming_and_raises_DinnerCancelled_with_reason()
+    {
+        var clock = Clock();
+        var dinner = NewUpcoming(clock);
+        dinner.AcceptChanges();
+
+        var result = dinner.Cancel("host illness", clock);
+
+        result.IsSuccess.Should().BeTrue();
+        dinner.Status.Should().Be(DinnerStatus.Cancelled);
+        dinner.CancelledAt.Should().Be(Now);
+        dinner.CancellationReason.Should().Be("host illness");
+        dinner.EndedAt.Should().BeNull("Cancelled and Ended are semantically distinct");
+        var ev = dinner.UncommittedEvents().Should().ContainSingle().Which.Should().BeOfType<DinnerCancelled>().Subject;
+        ev.Reason.Should().Be("host illness");
+        ev.OccurredAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void Cancel_from_InProgress_is_rejected_with_state_machine_reason_code()
+    {
+        var clock = Clock();
+        var dinner = NewUpcoming(clock);
+        dinner.Start(clock).GetValueOrThrow();
+        dinner.AcceptChanges();
+
+        var result = dinner.Cancel("too late", clock);
+
+        result.IsFailure.Should().BeTrue();
+        var error = result.Match(_ => null!, e => e).Should().BeOfType<Error.InvalidInput>().Subject;
+        error.Rules.Items.Should().ContainSingle()
+            .Which.ReasonCode.Should().Be("state.machine.invalid.transition");
+        dinner.Status.Should().Be(DinnerStatus.InProgress);
+        dinner.CancellationReason.Should().BeNull();
+    }
+
+    [Fact]
+    public void Cancel_rejects_blank_reason_before_consulting_state_machine()
+    {
+        var clock = Clock();
+        var dinner = NewUpcoming(clock);
+        dinner.AcceptChanges();
+
+        var result = dinner.Cancel("   ", clock);
+
+        result.IsFailure.Should().BeTrue();
+        var error = result.Match(_ => null!, e => e).Should().BeOfType<Error.InvalidInput>().Subject;
+        error.Fields.Items.Should().ContainSingle()
+            .Which.ReasonCode.Should().Be("dinner.cancel.reason-required");
+        dinner.Status.Should().Be(DinnerStatus.Upcoming);
+    }
+
+    [Fact]
+    public void Start_from_Ended_is_rejected()
+    {
+        var clock = Clock();
+        var dinner = NewUpcoming(clock);
+        dinner.Start(clock).GetValueOrThrow();
+        dinner.End(clock).GetValueOrThrow();
+        dinner.AcceptChanges();
+
+        var result = dinner.Start(clock);
+
+        result.IsFailure.Should().BeTrue();
+        dinner.Status.Should().Be(DinnerStatus.Ended);
+    }
+
+    [Fact]
+    public void Start_from_Cancelled_is_rejected()
+    {
+        var clock = Clock();
+        var dinner = NewUpcoming(clock);
+        dinner.Cancel("no longer needed", clock).GetValueOrThrow();
+        dinner.AcceptChanges();
+
+        var result = dinner.Start(clock);
+
+        result.IsFailure.Should().BeTrue();
+        dinner.Status.Should().Be(DinnerStatus.Cancelled);
+    }
+}
+

--- a/Infrastructure/src/DependencyInjection.cs
+++ b/Infrastructure/src/DependencyInjection.cs
@@ -7,6 +7,7 @@ using BuberDinner.Application.Abstractions.Persistence;
 using BuberDinner.Domain.Menu;
 using BuberDinner.Domain.User.Entities;
 using HostEntity = BuberDinner.Domain.Host.Entities.Host;
+using DinnerEntity = BuberDinner.Domain.Dinner.Entities.Dinner;
 using BuberDinner.Infrastructure.Authentication;
 using BuberDinner.Infrastructure.Persistence.Cosmos;
 using BuberDinner.Infrastructure.Persistence.Memory;
@@ -66,6 +67,12 @@ public static class DependencyInjection
         // POST /hosts or PUT /hosts/.../menus/... (which loads the parent Host for
         // IAuthorizeResource<Host>). Tracked alongside the broader 5-PR showcase roadmap.
         services.AddScoped<IRepository<HostEntity>, HostInMemoryRepository>();
+        // TODO: replace with DinnerCosmosDbRepository when implemented. Same stop-gap rationale
+        // as Host above — Dinner aggregates land in the in-memory store regardless of the
+        // configured persistence mode until a Cosmos implementation ships.
+        services.AddScoped<DinnerInMemoryRepository>();
+        services.AddScoped<IRepository<DinnerEntity>>(sp => sp.GetRequiredService<DinnerInMemoryRepository>());
+        services.AddScoped<IDinnerRepository>(sp => sp.GetRequiredService<DinnerInMemoryRepository>());
         return services;
     }
 
@@ -74,6 +81,9 @@ public static class DependencyInjection
         services.AddScoped<IRepository<User>, UserInMemoryRepository>();
         services.AddScoped<IRepository<Menu>, MenuInMemoryRepository>();
         services.AddScoped<IRepository<HostEntity>, HostInMemoryRepository>();
+        services.AddScoped<DinnerInMemoryRepository>();
+        services.AddScoped<IRepository<DinnerEntity>>(sp => sp.GetRequiredService<DinnerInMemoryRepository>());
+        services.AddScoped<IDinnerRepository>(sp => sp.GetRequiredService<DinnerInMemoryRepository>());
         return services;
     }
 }

--- a/Infrastructure/src/Persistence/Memory/DinnerInMemoryRepository.cs
+++ b/Infrastructure/src/Persistence/Memory/DinnerInMemoryRepository.cs
@@ -1,0 +1,86 @@
+namespace BuberDinner.Infrastructure.Persistence.Memory;
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.Dinner.Entities;
+using BuberDinner.Domain.Host.ValueObject;
+
+/// <summary>
+/// In-memory <see cref="IRepository{T}"/> for <see cref="Dinner"/>. Mirrors
+/// <see cref="MenuInMemoryRepository"/>: a static aggregate list plus a parallel ETag
+/// dictionary, with the ETag written back onto the aggregate via reflection
+/// (<see cref="AggregateETagWriter"/>) because the framework's ETag setter is internal
+/// (framework regression reg-005).
+/// </summary>
+internal class DinnerInMemoryRepository : IDinnerRepository
+{
+    private static readonly List<Dinner> s_dinners = new();
+    private static readonly ConcurrentDictionary<string, string> s_etags = new(StringComparer.Ordinal);
+    private static readonly object s_lock = new();
+
+    public IEnumerable<Dinner> GetAll(CancellationToken cancellationToken)
+    {
+        lock (s_lock)
+            return s_dinners.ToList();
+    }
+
+    /// <summary>Reads every dinner owned by the supplied host. Used by the per-host list query.</summary>
+    public IReadOnlyList<Dinner> GetForHost(HostId hostId)
+    {
+        lock (s_lock)
+            return s_dinners.Where(d => d.HostId == hostId).ToList();
+    }
+
+    public ValueTask Add(Dinner dinner, CancellationToken cancellationToken)
+    {
+        lock (s_lock)
+        {
+            s_dinners.Add(dinner);
+            BumpETag(dinner);
+        }
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask Update(Dinner dinner, CancellationToken cancellationToken)
+    {
+        lock (s_lock)
+        {
+            int index = s_dinners.FindIndex(d => d.Id == dinner.Id);
+            if (index < 0)
+                s_dinners.Add(dinner);
+            else
+                s_dinners[index] = dinner;
+            BumpETag(dinner);
+        }
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask Delete(Dinner dinner, CancellationToken cancellationToken)
+    {
+        lock (s_lock)
+        {
+            s_dinners.RemoveAll(d => d.Id == dinner.Id);
+            s_etags.TryRemove(dinner.Id.Value.ToString(), out _);
+        }
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<Dinner?> FindById(string id, CancellationToken cancellationToken)
+    {
+        Dinner? dinner;
+        lock (s_lock)
+            dinner = s_dinners.SingleOrDefault(d => d.Id.Value.ToString() == id);
+        if (dinner is not null && s_etags.TryGetValue(id, out var etag))
+            AggregateETagWriter.SetETag(dinner, etag);
+        return ValueTask.FromResult(dinner);
+    }
+
+    private static void BumpETag(Dinner dinner)
+    {
+        var newETag = Guid.NewGuid().ToString("N");
+        s_etags[dinner.Id.Value.ToString()] = newETag;
+        AggregateETagWriter.SetETag(dinner, newETag);
+    }
+}

--- a/Requests/Dinners/CancelDinner.http
+++ b/Requests/Dinners/CancelDinner.http
@@ -1,0 +1,30 @@
+### Cancel a dinner that hasn't started yet (`Upcoming` -> `Cancelled`). Takes a JSON body
+### with a non-blank `reason`. Raises `DinnerCancelled` with the reason embedded — so a
+### notification handler can include "We're sorry, this dinner was cancelled because ..."
+### in the message it sends to guests.
+###
+### Semantic distinction (Cookbook Recipe 9 §697): `Cancelled` means "never happened".
+### A dinner that has started and then terminates early transitions to `Ended` instead,
+### NOT `Cancelled`. Cancelling once `InProgress` returns 422 (see Cancel-InvalidTransition.http).
+
+@token = yourtoken
+@hostId = 019E955C-89A3-7F92-A289-35F8823BC135
+@dinnerId = 019E95A2-5735-71C1-A435-F78C5C2D6182
+
+POST {{host}}/hosts/{{hostId}}/dinners/{{dinnerId}}/cancel?api-version=2022-10-01
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "reason": "Host illness"
+}
+
+### Expected response:
+### HTTP/1.1 200 OK
+### ETag: "<new-etag>"
+### {
+###   ..., "status": "Cancelled",
+###   "cancelledAt": "2026-06-05T02:35:48.949Z",
+###   "cancellationReason": "Host illness",
+###   "startedAt": null, "endedAt": null
+### }

--- a/Requests/Dinners/EndDinner.http
+++ b/Requests/Dinners/EndDinner.http
@@ -1,0 +1,18 @@
+### Transition a dinner from `InProgress` to `Ended`. Body-less. Raises `DinnerEnded`.
+
+@token = yourtoken
+@hostId = 019E955C-89A3-7F92-A289-35F8823BC135
+@dinnerId = 019E95A2-5735-71C1-A435-F78C5C2D6182
+
+POST {{host}}/hosts/{{hostId}}/dinners/{{dinnerId}}/end?api-version=2022-10-01
+Authorization: Bearer {{token}}
+
+### Expected response (happy path):
+### HTTP/1.1 200 OK
+### ETag: "<new-etag>"
+### { ..., "status": "Ended", "startedAt": "...", "endedAt": "..." }
+###
+### Expected response (called before /start):
+### HTTP/1.1 422 Unprocessable Entity
+### { rules: [{ code: "state.machine.invalid.transition",
+###             detail: "Trigger 'End' is not permitted from state 'Upcoming'." }] }

--- a/Requests/Dinners/GetDinner.http
+++ b/Requests/Dinners/GetDinner.http
@@ -1,0 +1,20 @@
+### Get a dinner by id. Emits a strong ETag for conditional reads (Cookbook Recipe 6).
+### Status transitions through Upcoming -> InProgress -> Ended via the /start and /end POSTs.
+
+@token = yourtoken
+@hostId = 019E955C-89A3-7F92-A289-35F8823BC135
+@dinnerId = 019E95A2-5735-71C1-A435-F78C5C2D6182
+
+GET {{host}}/hosts/{{hostId}}/dinners/{{dinnerId}}?api-version=2022-10-01
+Authorization: Bearer {{token}}
+
+### Expected response:
+### HTTP/1.1 200 OK
+### ETag: "<strong-etag>"
+### {
+###   "id": "...", "status": "Upcoming" | "InProgress" | "Ended" | "Cancelled",
+###   "startedAt": null or ISO timestamp,
+###   "endedAt":   null or ISO timestamp,
+###   "cancelledAt": null or ISO timestamp,
+###   "cancellationReason": null or string
+### }

--- a/Requests/Dinners/Lifecycle-InvalidTransition.http
+++ b/Requests/Dinners/Lifecycle-InvalidTransition.http
@@ -1,0 +1,49 @@
+### Two failure modes for the lifecycle POSTs, side by side:
+###
+###   1. Cancel after Start  -> 422 with state.machine.invalid.transition
+###   2. Cross-host start    -> 403 Forbidden via IAuthorizeResource<Host>
+###
+### Both failure modes are first-class showcase scenarios for PR 2 and are locked in by
+### the DinnerStateMachineTests integration suite.
+
+@token = yourtoken
+@otherToken = yourothertoken
+@hostId = 019E955C-89A3-7F92-A289-35F8823BC135
+@dinnerId = 019E95A2-5735-71C1-A435-F78C5C2D6182
+
+### 1. Cancel a dinner that's already InProgress -> 422.
+###    The state machine refuses the transition; CancellationReason stays null and the
+###    aggregate stays in InProgress (verified by a subsequent GET).
+
+POST {{host}}/hosts/{{hostId}}/dinners/{{dinnerId}}/cancel?api-version=2022-10-01
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "reason": "Too late"
+}
+
+### Expected response:
+### HTTP/1.1 422 Unprocessable Entity
+### Content-Type: application/problem+json
+### {
+###   "status": 422,
+###   "detail": "Trigger 'Cancel' is not permitted from state 'InProgress'.",
+###   "code": "invalid-input",
+###   "rules": [{ "code": "state.machine.invalid.transition", ... }]
+### }
+
+
+### 2. Start a dinner as a user who does NOT own the route host -> 403.
+###    Resource-based authorization (UpdateMenuCommand pattern) sets the code to
+###    "dinners.owner" so callers can distinguish ownership failures from other 403s.
+
+POST {{host}}/hosts/{{hostId}}/dinners/{{dinnerId}}/start?api-version=2022-10-01
+Authorization: Bearer {{otherToken}}
+
+### Expected response:
+### HTTP/1.1 403 Forbidden
+### Content-Type: application/problem+json
+### {
+###   "status": 403, "code": "dinners.owner", "kind": "forbidden"
+### }

--- a/Requests/Dinners/ListDinners.http
+++ b/Requests/Dinners/ListDinners.http
@@ -1,13 +1,16 @@
-### TODO: ListDinners endpoint not yet implemented.
-### BuberDinner.Domain.Dinner currently has only a DinnerId value object — no Dinner aggregate,
-### no controller, no handler. This file is aspirational; the request below will 404 until
-### a Dinners controller is added (likely future PR: paginated list using Trellis Page<T> +
-### Cursor + ToPageAsync, see cookbook Recipe 3).
-###
-### Keeping the file as a placeholder so the planned shape is visible from the Requests/
-### tree, but it does NOT exercise a live endpoint today.
+### List all dinners owned by the route host. Simple (non-paginated) for PR 2 —
+### PR 3 will switch this to `Page<T>` + `Cursor` per Cookbook Recipe 3.
 
 @token = yourtoken
-GET {{host}}/dinners?api-version=2022-10-01
+@hostId = 019E955C-89A3-7F92-A289-35F8823BC135
+
+GET {{host}}/hosts/{{hostId}}/dinners?api-version=2022-10-01
 Authorization: Bearer {{token}}
 
+### Expected response:
+### HTTP/1.1 200 OK
+### Content-Type: application/json
+### [
+###   { "id": "...", "name": "Brunch with friends", "status": "Upcoming", ... },
+###   { "id": "...", "name": "Another dinner",       "status": "Cancelled", ... }
+### ]

--- a/Requests/Dinners/ScheduleDinner.http
+++ b/Requests/Dinners/ScheduleDinner.http
@@ -1,0 +1,40 @@
+### Schedule a new dinner under the route host. Resource auth gates by Host ownership;
+### the handler also verifies the supplied menuId belongs to the same host (404 if not).
+### Validates EndDateTime > StartDateTime (422 if not).
+
+@token = yourtoken
+@hostId = 019E955C-89A3-7F92-A289-35F8823BC135
+@menuId = 019E955C-8A14-7B4C-8B40-F82FFB3B05F1
+
+POST {{host}}/hosts/{{hostId}}/dinners?api-version=2022-10-01
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "name": "Brunch with friends",
+    "description": "Casual Sunday brunch",
+    "menuId": "{{menuId}}",
+    "startDateTime": "2026-07-01T18:00:00Z",
+    "endDateTime": "2026-07-01T21:00:00Z"
+}
+
+### Expected response shape:
+### HTTP/1.1 201 Created
+### ETag: "<strong-etag>"
+### Location: /hosts/{hostId}/dinners/{dinnerId}
+### Content-Type: application/json
+### {
+###   "id": "019e95a2-5735-71c1-a435-f78c5c2d6182",
+###   "name": "Brunch with friends",
+###   "description": "Casual Sunday brunch",
+###   "hostId": "...",
+###   "menuId": "...",
+###   "status": "Upcoming",
+###   "startDateTime": "2026-07-01T18:00:00+00:00",
+###   "endDateTime":   "2026-07-01T21:00:00+00:00",
+###   "startedAt": null, "endedAt": null,
+###   "cancelledAt": null, "cancellationReason": null
+### }
+###
+### Side effect (visible in server logs, captured by integration tests):
+###   info: LogDinnerScheduledHandler[0] Dinner X scheduled for host Y from ... to ...

--- a/Requests/Dinners/StartDinner.http
+++ b/Requests/Dinners/StartDinner.http
@@ -1,0 +1,28 @@
+### Transition a dinner from `Upcoming` to `InProgress`. Body-less per Cookbook Recipe 23 —
+### state machines on POST endpoints substitute for `If-Match` (an invalid transition is a
+### semantic rule violation, not a concurrent-modification conflict).
+###
+### On success: 200 OK + new ETag + body reflecting `status: "InProgress"` and `startedAt`
+### populated to the server's wall-clock at transition time. A `DinnerStarted` domain event
+### is published to every registered IDomainEventHandler<DinnerStarted>.
+
+@token = yourtoken
+@hostId = 019E955C-89A3-7F92-A289-35F8823BC135
+@dinnerId = 019E95A2-5735-71C1-A435-F78C5C2D6182
+
+POST {{host}}/hosts/{{hostId}}/dinners/{{dinnerId}}/start?api-version=2022-10-01
+Authorization: Bearer {{token}}
+
+### Expected response (happy path):
+### HTTP/1.1 200 OK
+### ETag: "<new-etag>"
+### { ..., "status": "InProgress", "startedAt": "2026-07-01T18:00:00.123Z", ... }
+###
+### Expected response (invalid transition — already InProgress or Ended/Cancelled):
+### HTTP/1.1 422 Unprocessable Entity
+### Content-Type: application/problem+json
+### {
+###   "status": 422, "code": "invalid-input",
+###   "rules": [{ "code": "state.machine.invalid.transition",
+###               "detail": "Trigger 'Start' is not permitted from state 'InProgress'." }]
+### }


### PR DESCRIPTION
# PR 2 — Dinner state machine + domain events

> *Second in the 5-PR showcase arc. PR 1 (#27) added ETag + resource auth; PR 2 adds the
> first aggregate driven by a Stateless state machine, with per-transition domain events
> dispatched through the Trellis Mediator pipeline.*

## TL;DR

| What | Where | Cookbook |
|---|---|---|
| `Dinner` aggregate with `LazyStateMachine<DinnerStatus, DinnerTrigger>` | `Domain/src/Dinner/Entities/Dinner.cs` | Recipe 9 |
| `RequiredEnum<TSelf>` for both states and triggers | `Domain/src/Dinner/ValueObjects/` | Recipe 9 |
| 4 domain events, `OccurredAt` as the only timestamp | `Domain/src/Dinner/Events/DinnerEvents.cs` | Recipe 17 |
| `POST /hosts/{hostId:HostId}/dinners` — schedule, validates Menu→Host membership | `DinnersController.ScheduleDinner` | Recipe 22 |
| `GET .../dinners` and `.../dinners/{dinnerId:DinnerId}` with strong ETag | `DinnersController` | Recipe 6 |
| `POST .../start` `/end` `/cancel` — body-less state transitions | `DinnersController` | Recipe 23 |
| Resource auth on every mutation (`dinners.owner`) | each `*Command : IAuthorizeResource<Host>` | Recipe 7 |
| Per-handler `IDomainEventHandler<TEvent>` registration (AOT-safe) | `Api/src/DependencyInjection.cs` | Mediator §547 |
| `TimeProvider.System` injection (FakeTimeProvider-friendly tests) | DI + `Dinner.TryCreate(..., clock)` | Recipe 17 |

## The whole state machine in 9 lines

```csharp
private static void ConfigureMachine(StateMachine<DinnerStatus, DinnerTrigger> machine)
{
    machine.Configure(DinnerStatus.Upcoming)
           .Permit(DinnerTrigger.Start,  DinnerStatus.InProgress)
           .Permit(DinnerTrigger.Cancel, DinnerStatus.Cancelled);

    machine.Configure(DinnerStatus.InProgress)
           .Permit(DinnerTrigger.End,    DinnerStatus.Ended);

    // Ended and Cancelled are terminal.
}
```

`Ended` and `Cancelled` are kept semantically distinct: `Cancelled` = the dinner *never
happened* (only from `Upcoming`); `Ended` = the dinner *ran to completion* (only from
`InProgress`). Downstream refund/no-show/calendar logic depends on this distinction.

## Build, test, wire-verify

- **0 warnings / 0 errors**
- **Domain 29/29** (10 new Dinner tests)
- **Application 1/1**
- **Api 44/44** (8 new Dinner integration tests, including event-dispatch verification with a per-test `CapturedEvents` sink)
- Infrastructure 0/2 (live-Cosmos baseline, pre-existing)
- All 9 wire scenarios verified by curl + DinnerStateMachineTests:
  - 201 Schedule + ETag + Location
  - 200 GET single + ETag
  - 200 List
  - 200 Start + new ETag
  - 422 Start when InProgress (reason code `state.machine.invalid.transition`)
  - 200 End
  - 200 Cancel from Upcoming + reason
  - 422 Cancel from InProgress (state-machine reject)
  - 403 Cross-host transition (`code: "dinners.owner"`)
  - 404 Schedule with foreign Menu (referential check in handler)

## The most important catch from /review (PR-1 style critique applied pre-implementation)

The rubber-duck pre-implementation critique flagged a **silent runtime failure** I would have shipped otherwise:

`DomainEventDispatchBehavior` is constrained to `where TMessage : ICommand<TResponse>` ([trellis-api-mediator.md:677](.github/trellis-api-mediator.md)). Marking a Dinner command as `IRequest<Result<Dinner>>` (the convention the rest of the codebase uses) would have silently skipped dispatch — every handler registered, none firing, no compile-time or startup-time signal.

Every Dinner-mutating command in this PR uses `ICommand<Result<Dinner>>`. Existing `CreateMenuCommand`/`UpdateMenuCommand` still use `IRequest<>` because they don't raise events — migrating them is harmless follow-on but not in scope for PR 2.

The same critique also caught:

- `Dinner.TryCreate` needed a `TimeProvider` to stamp `DinnerScheduled.OccurredAt` (now does).
- `ScheduleDinnerHandler` had to verify `Menu.HostId == route.HostId` (otherwise a host could schedule against another host's menu — resource auth only proves the host is yours, not the menu). Added; covered by `Schedule_dinner_with_foreign_menu_returns_404`.
- `[Consumes("application/json")]` moved off the controller-level and onto only the body-bearing actions (Schedule, Cancel) so the body-less `/start` and `/end` POSTs don't return 415 when a client omits `Content-Type`.

## Commit walkthrough (7 commits)

| # | sha | Scope |
|---|---|---|
| 1 | `307fcb5` | `chore(deps)`: Trellis.StateMachine + Stateless + FakeTimeProvider |
| 2 | `36e4097` | `feat(domain)`: Dinner aggregate + state machine + 4 events + 10 tests |
| 3 | `a99d1e8` | `feat(infra)`: DinnerInMemoryRepository with ETag tracking |
| 4 | `4705f10` | `feat(app)`: 4 commands (`ICommand<Result<Dinner>>`), 2 queries, 4 log handlers, `IDinnerRepository` |
| 5 | `040fa9b` | `feat(api)`: DinnersController, DTOs, Mapster mapping, event/TimeProvider DI |
| 6 | `7e93b06` | `test(api)`: 8 integration tests with per-test `CapturedEvents` sink |
| 7 | `d69f8fb` | `docs`: `Docs/PR2_DINNER_STATE_MACHINE.md` + Aggregates.Dinner.md + 7 `.http` files |

## What's NOT in this PR (deferred)

- **Pagination** for `GET /dinners` — currently returns a plain array. PR 3 introduces `Page<Dinner>` + `Cursor` per Recipe 3.
- **Real notification side effects** — the four `IDomainEventHandler<TEvent>` impls are log-only. PR 4 (Bookings) will add an outbox-style integration-event publisher that pushes guest notifications.
- **Cosmos persistence for Dinner** — same in-memory stop-gap as Host (PR 1 Cosmos DI gap fix). `// TODO: replace with DinnerCosmosDbRepository when implemented`.
- **Reservations / Location / Price** on the aggregate — design doc deferred to PR 4+.
- **`Cancel` from `InProgress`** — explicitly rejected here. If a real "host called it off after it started" use case arrives, the right answer is a fifth status `EndedEarly` reached via a new `EndEarly(reason)` transition, not overloading `Cancel`.

## Roadmap remaining

- PR 3: Pagination (`Page<T>` + `Cursor`) for List endpoints
- PR 4: Bookings + idempotency + outbox event publisher (multi-aggregate Recipe 22)
- PR 5: Reviews + `AddTrellisFluentValidation` at command boundary + `Trellis.Testing` + ServiceDefaults
