### PR TITLE
feat: cursor pagination on /dinners and /menus (Trellis Page<T> + Cursor + PageBuilder)

### DIFF
--- a/Api/src/2022-12-21/Controllers/DinnersController.cs
+++ b/Api/src/2022-12-21/Controllers/DinnersController.cs
@@ -83,7 +83,13 @@ public class DinnersController : ControllerBase
         [FromQuery(Name = "limit")] int? limit,
         CancellationToken cancellationToken)
     {
-        var basePath = $"/hosts/{hostId.Value}/dinners";
+        // Framework contract (trellis-api-asp.md:86 / :383): nextUrlBuilder must return an
+        // ABSOLUTE URL. The cursor flows into PageLink.Href on the JSON envelope AND the
+        // RFC 8288 `Link: <href>; rel="next"` header — both downstream consumers (clients
+        // queueing the cursor for later, share-the-cursor flows, HATEOAS schedulers) expect
+        // a fully-qualified URI they can hand to `new Uri(...)` without a base.
+        var origin = $"{Request.Scheme}://{Request.Host}";
+        var basePath = $"{origin}/hosts/{hostId.Value}/dinners";
         var apiVersion = HttpContext.GetRequestedApiVersion()?.ToString() ?? "2022-10-01";
 
         return await _sender.Send(

--- a/Api/src/2022-12-21/Controllers/DinnersController.cs
+++ b/Api/src/2022-12-21/Controllers/DinnersController.cs
@@ -64,16 +64,40 @@ public class DinnersController : ControllerBase
             .AsActionResultAsync<DinnerResponse>();
 
     /// <summary>
-    /// Lists every dinner owned by the route host. PR 3 will replace this with paginated
-    /// <see cref="Trellis.Page{T}"/> + <see cref="Trellis.Cursor"/> output.
+    /// Lists dinners owned by the route host with cursor-based pagination (Cookbook Recipe 3).
+    /// <list type="bullet">
+    ///   <item><c>?limit=N</c> requests at most <c>N</c> items per page; server caps at <c>PageSize.Max</c>.
+    ///         Omitted/zero/negative → <c>PageSize.Default</c>.</item>
+    ///   <item><c>?cursor=&lt;opaque&gt;</c> resumes from the previous page's <c>next</c> token.
+    ///         Malformed cursors → 422 with reason code <c>cursor.malformed</c>.</item>
+    /// </list>
+    /// Uses Trellis.Asp's <c>Result&lt;Page&lt;T&gt;&gt;.ToHttpResponseAsync</c> overload so the
+    /// envelope, RFC 8288 <c>Link</c> header, and next/previous <c>PageLink</c> records are all
+    /// emitted by the framework.
     /// </summary>
     [HttpGet]
-    public async ValueTask<ActionResult<DinnerResponse[]>> ListDinners(
-        HostId hostId, CancellationToken cancellationToken) =>
-        await _sender.Send(new ListDinnersForHostQuery(hostId), cancellationToken)
+    [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
+    public async ValueTask<ActionResult<Trellis.Asp.PagedResponse<DinnerResponse>>> ListDinners(
+        HostId hostId,
+        [FromQuery(Name = "cursor")] string? cursor,
+        [FromQuery(Name = "limit")] int? limit,
+        CancellationToken cancellationToken)
+    {
+        var basePath = $"/hosts/{hostId.Value}/dinners";
+        var apiVersion = HttpContext.GetRequestedApiVersion()?.ToString() ?? "2022-10-01";
+
+        return await _sender.Send(
+                new ListDinnersForHostQuery(
+                    hostId,
+                    cursor is { Length: > 0 } token ? new Cursor(token) : (Cursor?)null,
+                    limit),
+                cancellationToken)
             .ToHttpResponseAsync(
-                body: dinners => dinners.Select(d => d.Adapt<DinnerResponse>()).ToArray())
-            .AsActionResultAsync<DinnerResponse[]>();
+                nextUrlBuilder: (nextCursor, appliedLimit) =>
+                    $"{basePath}?cursor={Uri.EscapeDataString(nextCursor.Token)}&limit={appliedLimit}&api-version={apiVersion}",
+                body: dinner => dinner.Adapt<DinnerResponse>())
+            .AsActionResultAsync<Trellis.Asp.PagedResponse<DinnerResponse>>();
+    }
 
     /// <summary>
     /// Get a dinner by id. Emits a strong ETag (Cookbook Recipe 6) — though dinners are

--- a/Api/src/2022-12-21/Controllers/MenusController.cs
+++ b/Api/src/2022-12-21/Controllers/MenusController.cs
@@ -11,7 +11,6 @@ using Mediator;
 using Microsoft.AspNetCore.Mvc;
 using Trellis;
 using Trellis.Asp;
-
 /// <summary>
 /// CRUD for menu.
 /// </summary>
@@ -33,6 +32,41 @@ public class MenusController : ControllerBase
     public MenusController(ISender sender)
     {
         _sender = sender;
+    }
+
+    /// <summary>
+    /// Lists menus owned by the route host with cursor-based pagination (Cookbook Recipe 3).
+    /// Mirrors the shape of <see cref="DinnersController.ListDinners"/> exactly — same query
+    /// params (<c>?cursor</c> / <c>?limit</c>), same <c>PagedResponse&lt;T&gt;</c> envelope,
+    /// same RFC 8288 <c>Link</c> header.
+    /// </summary>
+    /// <param name="hostId">The id of the host whose menus are being listed.</param>
+    /// <param name="cursor">Opaque continuation token from the previous page's <c>next</c>. Null on the first page.</param>
+    /// <param name="limit">Requested page size (clamped to <c>PageSize.Max</c>); falls back to <c>PageSize.Default</c> when null/non-positive.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
+    public async ValueTask<ActionResult<PagedResponse<MenuResponse>>> ListMenus(
+        HostId hostId,
+        [FromQuery(Name = "cursor")] string? cursor,
+        [FromQuery(Name = "limit")] int? limit,
+        CancellationToken cancellationToken)
+    {
+        var basePath = $"/hosts/{hostId.Value}/menus";
+        var apiVersion = HttpContext.GetRequestedApiVersion()?.ToString() ?? "2022-10-01";
+
+        return await _sender.Send(
+                new ListMenusForHostQuery(
+                    hostId,
+                    cursor is { Length: > 0 } token ? new Cursor(token) : (Cursor?)null,
+                    limit),
+                cancellationToken)
+            .ToHttpResponseAsync(
+                nextUrlBuilder: (nextCursor, appliedLimit) =>
+                    $"{basePath}?cursor={Uri.EscapeDataString(nextCursor.Token)}&limit={appliedLimit}&api-version={apiVersion}",
+                body: menu => menu.Adapt<MenuResponse>())
+            .AsActionResultAsync<PagedResponse<MenuResponse>>();
     }
 
     /// <summary>

--- a/Api/src/2022-12-21/Controllers/MenusController.cs
+++ b/Api/src/2022-12-21/Controllers/MenusController.cs
@@ -53,7 +53,9 @@ public class MenusController : ControllerBase
         [FromQuery(Name = "limit")] int? limit,
         CancellationToken cancellationToken)
     {
-        var basePath = $"/hosts/{hostId.Value}/menus";
+        // Framework contract (trellis-api-asp.md:86): nextUrlBuilder must return an absolute URL.
+        var origin = $"{Request.Scheme}://{Request.Host}";
+        var basePath = $"{origin}/hosts/{hostId.Value}/menus";
         var apiVersion = HttpContext.GetRequestedApiVersion()?.ToString() ?? "2022-10-01";
 
         return await _sender.Send(

--- a/Api/tests/2022-12-21/DinnerStateMachineTests.cs
+++ b/Api/tests/2022-12-21/DinnerStateMachineTests.cs
@@ -171,10 +171,13 @@ public class DinnerStateMachineTests
         var response = await client.GetAsync(DinnersUrl(hostId));
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var list = await response.Content.ReadAsAsync<DinnerResponseBody[]>();
-        list!.Length.Should().BeGreaterOrEqualTo(2);
-        list.Should().OnlyContain(d => d.HostId == hostId);
+        // PR 3 wraps the list in a Trellis.Asp.PagedResponse<T> envelope.
+        var page = await response.Content.ReadAsAsync<PagedDinnerEnvelope>();
+        page!.Items.Length.Should().BeGreaterOrEqualTo(2);
+        page.Items.Should().OnlyContain(d => d.HostId == hostId);
     }
+
+    private sealed record PagedDinnerEnvelope(DinnerResponseBody[] Items);
 
     // ------------------------ helpers ------------------------
 

--- a/Api/tests/2022-12-21/PaginationTests.cs
+++ b/Api/tests/2022-12-21/PaginationTests.cs
@@ -167,6 +167,10 @@ public class PaginationTests
         var crossPage = await GetPageAsync<DinnerBody>(
             foreignClient, $"hosts/{foreignHost}/dinners", limit: 2, cursor: ownerPaged.Next!.Cursor);
 
+        crossPage.Items.Count.Should().Be(2,
+            "limit=2 must be respected after the host filter; Bug-pattern: 'Take(N+1) applied " +
+            "BEFORE Where(host=B)' would return fewer than 2 items (Take eats mixed-host rows " +
+            "then host-filter prunes most of them away). Asserting count catches this.");
         crossPage.Items.Should().OnlyContain(d => d.HostId == foreignHost,
             "host filter is applied BEFORE the cursor seek; a stolen cursor cannot leak another host's rows");
         crossPage.Items.Should().NotContain(d => ownerPage.Items.Any(o => o.Id == d.Id),

--- a/Api/tests/2022-12-21/PaginationTests.cs
+++ b/Api/tests/2022-12-21/PaginationTests.cs
@@ -1,0 +1,246 @@
+namespace BuberDinner.Api.Tests._2022_12_21;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit.Priority;
+
+/// <summary>
+/// Integration coverage for cursor-based pagination on the per-host list endpoints
+/// (<c>GET /hosts/{hostId}/dinners</c> and <c>GET /hosts/{hostId}/menus</c>) per
+/// Cookbook Recipe 3.
+///
+/// Each test creates its own host so the static in-memory store doesn't leak across tests.
+/// </summary>
+[TestCaseOrderer(PriorityOrderer.Name, PriorityOrderer.Assembly)]
+public class PaginationTests
+    : IClassFixture<WebApplicationFactory<Program>>
+{
+    private const string ApiVersion = "?api-version=2022-10-01";
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public PaginationTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact, Priority(4)]
+    public async Task ListDinners_paginates_across_pages_then_terminates_with_null_next()
+    {
+        var (client, hostId, menuId) = await SetupHostAndMenuAsync();
+        await ScheduleNDinnersAsync(client, hostId, menuId, count: 12);
+
+        var p1 = await GetPageAsync<DinnerBody>(client, $"hosts/{hostId}/dinners", limit: 5);
+        p1.Items.Count.Should().Be(5);
+        p1.Next.Should().NotBeNull("the first page must carry a forward cursor when more rows exist");
+        p1.Next!.Cursor.Should().NotBeNullOrEmpty();
+        p1.Next.Href.Should().Contain("cursor=").And.Contain("limit=5");
+        p1.WasCapped.Should().BeFalse();
+        p1.RequestedLimit.Should().Be(5);
+        p1.AppliedLimit.Should().Be(5);
+
+        var p2 = await GetPageAsync<DinnerBody>(client, $"hosts/{hostId}/dinners", limit: 5, cursor: p1.Next.Cursor);
+        p2.Items.Count.Should().Be(5);
+        p2.Next.Should().NotBeNull();
+
+        var p3 = await GetPageAsync<DinnerBody>(client, $"hosts/{hostId}/dinners", limit: 5, cursor: p2.Next!.Cursor);
+        p3.Items.Count.Should().Be(2, "12 total - 2 prior pages of 5 = 2 remaining");
+        p3.Next.Should().BeNull("the last page must NOT advertise a next cursor");
+
+        var allIds = p1.Items.Concat(p2.Items).Concat(p3.Items).Select(d => d.Id).ToList();
+        allIds.Should().OnlyHaveUniqueItems("no row may appear on two pages");
+        allIds.Should().BeInAscendingOrder("V7 GUIDs sort chronologically; the repo orders by Id.Value");
+    }
+
+    [Fact, Priority(4)]
+    public async Task ListDinners_returns_RFC8288_Link_header_for_next_page()
+    {
+        var (client, hostId, menuId) = await SetupHostAndMenuAsync();
+        await ScheduleNDinnersAsync(client, hostId, menuId, count: 3);
+
+        var raw = await client.GetAsync($"hosts/{hostId}/dinners{ApiVersion}&limit=2");
+
+        raw.StatusCode.Should().Be(HttpStatusCode.OK);
+        raw.Headers.TryGetValues("Link", out var linkValues).Should().BeTrue();
+        linkValues!.Should().ContainSingle()
+            .Which.Should().Contain("rel=\"next\"").And.Contain("cursor=").And.Contain("limit=2");
+    }
+
+    [Fact, Priority(4)]
+    public async Task ListDinners_clamps_oversized_limit_and_surfaces_WasCapped()
+    {
+        var (client, hostId, menuId) = await SetupHostAndMenuAsync();
+        await ScheduleNDinnersAsync(client, hostId, menuId, count: 3);
+
+        var page = await GetPageAsync<DinnerBody>(client, $"hosts/{hostId}/dinners", limit: 500);
+
+        page.RequestedLimit.Should().Be(500);
+        page.AppliedLimit.Should().Be(100, "PageSize.Max is the server-side ceiling");
+        page.WasCapped.Should().BeTrue();
+        page.Items.Count.Should().Be(3);
+        page.Next.Should().BeNull();
+    }
+
+    [Fact, Priority(4)]
+    public async Task ListDinners_malformed_cursor_returns_422_with_cursor_malformed_reason_code()
+    {
+        var (client, hostId, _) = await SetupHostAndMenuAsync();
+
+        var response = await client.GetAsync($"hosts/{hostId}/dinners{ApiVersion}&cursor=NOT-A-VALID-CURSOR-!!!");
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        var problem = await response.Content.ReadAsAsync<ProblemDetailsWithErrors>();
+        problem!.Status.Should().Be(422);
+        problem.Code.Should().Be("invalid-input");
+        problem.Errors.Should().ContainKey("cursor");
+    }
+
+    [Fact, Priority(4)]
+    public async Task ListDinners_default_limit_is_PageSize_Default_when_param_omitted()
+    {
+        var (client, hostId, menuId) = await SetupHostAndMenuAsync();
+        await ScheduleNDinnersAsync(client, hostId, menuId, count: 3);
+
+        var page = await GetPageAsync<DinnerBody>(client, $"hosts/{hostId}/dinners");
+
+        page.RequestedLimit.Should().Be(50, "PageSize.Default per Trellis convention");
+        page.AppliedLimit.Should().Be(50);
+        page.WasCapped.Should().BeFalse();
+    }
+
+    [Fact, Priority(4)]
+    public async Task ListMenus_paginates_with_same_envelope_as_ListDinners()
+    {
+        var (client, hostId, _) = await SetupHostAndMenuAsync();
+        // SetupHostAndMenuAsync already created 1 menu; add 11 more for a clean 12.
+        for (int i = 0; i < 11; i++)
+            await CreateMenuAsync(client, hostId);
+
+        var p1 = await GetPageAsync<MenuBody>(client, $"hosts/{hostId}/menus", limit: 5);
+        var p2 = await GetPageAsync<MenuBody>(client, $"hosts/{hostId}/menus", limit: 5, cursor: p1.Next!.Cursor);
+        var p3 = await GetPageAsync<MenuBody>(client, $"hosts/{hostId}/menus", limit: 5, cursor: p2.Next!.Cursor);
+
+        p1.Items.Count.Should().Be(5);
+        p2.Items.Count.Should().Be(5);
+        p3.Items.Count.Should().Be(2);
+        p3.Next.Should().BeNull();
+
+        var allIds = p1.Items.Concat(p2.Items).Concat(p3.Items).Select(m => m.Id).ToList();
+        allIds.Should().OnlyHaveUniqueItems().And.BeInAscendingOrder();
+    }
+
+    [Fact, Priority(4)]
+    public async Task Pagination_filters_by_host_so_one_hosts_cursor_does_not_leak_anothers_rows()
+    {
+        var (ownerClient, ownerHost, ownerMenu) = await SetupHostAndMenuAsync();
+        await ScheduleNDinnersAsync(ownerClient, ownerHost, ownerMenu, count: 4);
+
+        // Foreign host with its own data, in the SAME static repo.
+        var (foreignClient, foreignHost, foreignMenu) = await SetupHostAndMenuAsync();
+        await ScheduleNDinnersAsync(foreignClient, foreignHost, foreignMenu, count: 7);
+
+        var ownerPage = await GetPageAsync<DinnerBody>(ownerClient, $"hosts/{ownerHost}/dinners", limit: 50);
+        var foreignPage = await GetPageAsync<DinnerBody>(foreignClient, $"hosts/{foreignHost}/dinners", limit: 50);
+
+        ownerPage.Items.Should().HaveCount(4).And.OnlyContain(d => d.HostId == ownerHost);
+        foreignPage.Items.Should().HaveCount(7).And.OnlyContain(d => d.HostId == foreignHost);
+    }
+
+    // ---------------- helpers ----------------
+
+    private async Task<(HttpClient client, string hostId, string menuId)> SetupHostAndMenuAsync()
+    {
+        var client = _factory.CreateClient();
+        var userId = $"page_{Guid.NewGuid():N}".Substring(0, 16);
+        var registerBody = $$"""
+            { "userId":"{{userId}}", "firstName":"F", "lastName":"L",
+              "email":"{{userId}}@example.com", "password":"SecretP3$$word" }
+            """;
+        var register = await client.PostAsync("authentication/register",
+            new StringContent(registerBody, Encoding.UTF8, "application/json"));
+        register.EnsureSuccessStatusCode();
+        var token = (await register.Content.ReadAsAsync<TokenReply>())!.Token;
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var hostResp = await client.PostAsync($"hosts{ApiVersion}", JsonBody(new { displayName = "PageTest" }));
+        hostResp.StatusCode.Should().Be(HttpStatusCode.Created);
+        var hostId = (await hostResp.Content.ReadAsAsync<IdOnly>())!.Id;
+
+        var menuId = await CreateMenuAsync(client, hostId);
+        return (client, hostId, menuId);
+    }
+
+    private static async Task<string> CreateMenuAsync(HttpClient client, string hostId)
+    {
+        var menuResp = await client.PostAsync($"hosts/{hostId}/menus/create{ApiVersion}", JsonBody(new
+        {
+            name = $"M{Guid.NewGuid():N}".Substring(0, 8),
+            description = "d",
+            sections = new[]
+            {
+                new { name = "s", description = "d", items = new[] { new { name = "i", description = "d" } } }
+            }
+        }));
+        menuResp.StatusCode.Should().Be(HttpStatusCode.Created);
+        return (await menuResp.Content.ReadAsAsync<IdOnly>())!.Id;
+    }
+
+    private static async Task ScheduleNDinnersAsync(HttpClient client, string hostId, string menuId, int count)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            var body = new
+            {
+                name = $"D{i}",
+                description = "d",
+                menuId,
+                startDateTime = "2026-07-01T18:00:00Z",
+                endDateTime = "2026-07-01T21:00:00Z",
+            };
+            var resp = await client.PostAsync($"hosts/{hostId}/dinners{ApiVersion}", JsonBody(body));
+            resp.StatusCode.Should().Be(HttpStatusCode.Created);
+        }
+    }
+
+    private static async Task<PageEnvelope<T>> GetPageAsync<T>(
+        HttpClient client, string path, int? limit = null, string? cursor = null)
+    {
+        var url = $"{path}{ApiVersion}";
+        if (limit is { } l) url += $"&limit={l}";
+        if (cursor is { Length: > 0 }) url += $"&cursor={Uri.EscapeDataString(cursor)}";
+        var resp = await client.GetAsync(url);
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var page = await resp.Content.ReadAsAsync<PageEnvelope<T>>();
+        return page!;
+    }
+
+    private static StringContent JsonBody(object payload) =>
+        new(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+    // ----- wire shapes -----
+
+    private sealed record TokenReply(string Token);
+    private sealed record IdOnly(string Id);
+    private sealed record DinnerBody(string Id, string Name, string HostId);
+    private sealed record MenuBody(string Id);
+
+    private sealed record PageEnvelope<T>(
+        List<T> Items,
+        PageLink? Next,
+        PageLink? Previous,
+        int RequestedLimit,
+        int AppliedLimit,
+        int DeliveredCount,
+        bool WasCapped);
+
+    private sealed record PageLink(string Cursor, string Href);
+
+    private sealed record ProblemDetailsWithErrors(int Status, string? Code, Dictionary<string, string[]>? Errors);
+}

--- a/Api/tests/2022-12-21/PaginationTests.cs
+++ b/Api/tests/2022-12-21/PaginationTests.cs
@@ -42,6 +42,12 @@ public class PaginationTests
         p1.Next.Should().NotBeNull("the first page must carry a forward cursor when more rows exist");
         p1.Next!.Cursor.Should().NotBeNullOrEmpty();
         p1.Next.Href.Should().Contain("cursor=").And.Contain("limit=5");
+        // Framework contract (trellis-api-asp.md:86): next.href must be an absolute URL so
+        // out-of-band consumers (queued cursors, scheduled jobs, share-the-cursor flows) can
+        // hand it to `new Uri(...)` without a base.
+        Uri.TryCreate(p1.Next.Href, UriKind.Absolute, out var nextUri).Should().BeTrue(
+            "next.href must be an absolute URL, but got '{0}'", p1.Next.Href);
+        nextUri!.Scheme.Should().BeOneOf("http", "https");
         p1.WasCapped.Should().BeFalse();
         p1.RequestedLimit.Should().Be(5);
         p1.AppliedLimit.Should().Be(5);
@@ -151,6 +157,20 @@ public class PaginationTests
 
         ownerPage.Items.Should().HaveCount(4).And.OnlyContain(d => d.HostId == ownerHost);
         foreignPage.Items.Should().HaveCount(7).And.OnlyContain(d => d.HostId == foreignHost);
+
+        // The actual scenario this test's name advertises: take a cursor produced by host A's
+        // pagination and submit it against host B's URL. The host filter is applied BEFORE the
+        // cursor seek in the repo, so the response must contain ONLY host B's rows — never any
+        // row owned by host A — regardless of how the cursor was constructed.
+        var ownerPaged = await GetPageAsync<DinnerBody>(ownerClient, $"hosts/{ownerHost}/dinners", limit: 2);
+        ownerPaged.Next.Should().NotBeNull("setup needs a non-null cursor to swap onto the foreign host");
+        var crossPage = await GetPageAsync<DinnerBody>(
+            foreignClient, $"hosts/{foreignHost}/dinners", limit: 2, cursor: ownerPaged.Next!.Cursor);
+
+        crossPage.Items.Should().OnlyContain(d => d.HostId == foreignHost,
+            "host filter is applied BEFORE the cursor seek; a stolen cursor cannot leak another host's rows");
+        crossPage.Items.Should().NotContain(d => ownerPage.Items.Any(o => o.Id == d.Id),
+            "no owner-owned id may appear in the foreign host's page even when the cursor is swapped");
     }
 
     // ---------------- helpers ----------------

--- a/Application/src/Abstractions/Persistence/IDinnerRepository.cs
+++ b/Application/src/Abstractions/Persistence/IDinnerRepository.cs
@@ -6,14 +6,31 @@ using BuberDinner.Domain.Host.ValueObject;
 
 /// <summary>
 /// Dinner-specific repository surface. Extends the generic <see cref="IRepository{T}"/>
-/// with a per-host listing primitive so the application layer doesn't have to depend on
-/// any particular persistence implementation (or filter in memory after a full load).
+/// with per-host primitives so the application layer doesn't have to depend on any
+/// particular persistence implementation (or filter in memory after a full load).
 /// </summary>
-/// <remarks>
-/// PR 2 ships the in-memory implementation only; PR 3 will introduce a paginated
-/// equivalent (<c>Page&lt;Dinner&gt;</c> + <c>Cursor</c>) and the EF Core implementation.
-/// </remarks>
 public interface IDinnerRepository : IRepository<Dinner>
 {
+    /// <summary>
+    /// Returns every dinner owned by the supplied host, ordered by <see cref="Dinner.Id"/>
+    /// (V7 GUIDs sort chronologically by creation time).
+    /// </summary>
     IReadOnlyList<Dinner> GetForHost(HostId hostId);
+
+    /// <summary>
+    /// Returns an over-fetched, ordered, host-filtered slice for cursor-based pagination.
+    /// The handler in <c>ListDinnersForHostQueryHandler</c> passes the result to
+    /// <c>PageBuilder.FromOverFetch(...)</c>, which trims to <paramref name="pageSize"/>
+    /// items and emits a <see cref="System.Guid"/>-encoded <c>Next</c> cursor when more
+    /// rows exist beyond the page. Implementations MUST:
+    ///   1. Order by <see cref="Dinner.Id"/> ascending (V7 GUIDs sort chronologically).
+    ///   2. Filter to <paramref name="hostId"/> BEFORE seeking — every cursor seek is
+    ///      scoped to the same host so a cross-page navigation cannot leak rows from a
+    ///      different host even if a caller hands a stolen cursor to the wrong route host.
+    ///   3. Apply the seek predicate <c>Id.Value &gt; afterId</c> when <paramref name="afterId"/>
+    ///      is non-null (i.e. caller is on page 2+).
+    ///   4. Take at most <c>pageSize.Applied + 1</c> rows so the page builder can detect
+    ///      "is there a next page?" without an extra COUNT(*) query.
+    /// </summary>
+    IReadOnlyList<Dinner> GetPageForHost(HostId hostId, Trellis.PageSize pageSize, System.Guid? afterId);
 }

--- a/Application/src/Abstractions/Persistence/IMenuRepository.cs
+++ b/Application/src/Abstractions/Persistence/IMenuRepository.cs
@@ -1,0 +1,19 @@
+namespace BuberDinner.Application.Abstractions.Persistence;
+
+using System.Collections.Generic;
+using BuberDinner.Domain.Host.ValueObject;
+using BuberDinner.Domain.Menu;
+
+/// <summary>
+/// Menu-specific repository surface. Same pattern as <see cref="IDinnerRepository"/>:
+/// extends the generic <see cref="IRepository{T}"/> with per-host paginated reads so
+/// the application layer doesn't have to leak persistence details.
+/// </summary>
+public interface IMenuRepository : IRepository<Menu>
+{
+    /// <summary>
+    /// Over-fetched, host-filtered, id-ordered slice for cursor pagination. Same contract
+    /// as <see cref="IDinnerRepository.GetPageForHost"/> — see that XML doc for invariants.
+    /// </summary>
+    IReadOnlyList<Menu> GetPageForHost(HostId hostId, Trellis.PageSize pageSize, System.Guid? afterId);
+}

--- a/Application/src/Dinners/Queries/ListDinnersForHostQuery.cs
+++ b/Application/src/Dinners/Queries/ListDinnersForHostQuery.cs
@@ -1,6 +1,5 @@
 namespace BuberDinner.Application.Dinners.Queries;
 
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using BuberDinner.Application.Abstractions.Persistence;
@@ -9,21 +8,30 @@ using BuberDinner.Domain.Host.ValueObject;
 using Mediator;
 
 /// <summary>
-/// Lists all dinners owned by the supplied <see cref="HostId"/>. Simple (non-paginated)
-/// for PR 2 — full <c>Page&lt;T&gt;</c> + <c>Cursor</c> pagination lands in PR 3.
+/// Lists dinners owned by the supplied host with cursor-based pagination (Cookbook Recipe 3).
 /// </summary>
-public sealed class ListDinnersForHostQuery : IRequest<Result<IReadOnlyList<Dinner>>>
+/// <remarks>
+/// Both pagination knobs are protocol-level optionals: <see cref="Cursor"/> is <c>null</c>
+/// on the first page; <see cref="Limit"/> falls back to <see cref="PageSize.Default"/> when
+/// null or non-positive. Failures surface as <see cref="Error.InvalidInput"/> with reason
+/// code <c>cursor.malformed</c> (HTTP 422) per <c>CursorCodec.TryDecode</c>.
+/// </remarks>
+public sealed class ListDinnersForHostQuery : IRequest<Result<Page<Dinner>>>
 {
     public HostId HostId { get; }
+    public Cursor? Cursor { get; }
+    public int? Limit { get; }
 
-    public ListDinnersForHostQuery(HostId hostId)
+    public ListDinnersForHostQuery(HostId hostId, Cursor? cursor = null, int? limit = null)
     {
         HostId = hostId;
+        Cursor = cursor;
+        Limit = limit;
     }
 }
 
 public sealed class ListDinnersForHostQueryHandler
-    : IRequestHandler<ListDinnersForHostQuery, Result<IReadOnlyList<Dinner>>>
+    : IRequestHandler<ListDinnersForHostQuery, Result<Page<Dinner>>>
 {
     private readonly IDinnerRepository _repo;
 
@@ -32,10 +40,25 @@ public sealed class ListDinnersForHostQueryHandler
         _repo = repo;
     }
 
-    public ValueTask<Result<IReadOnlyList<Dinner>>> Handle(
+    public ValueTask<Result<Page<Dinner>>> Handle(
         ListDinnersForHostQuery request, CancellationToken cancellationToken)
     {
-        IReadOnlyList<Dinner> dinners = _repo.GetForHost(request.HostId);
-        return ValueTask.FromResult(Result.Ok(dinners));
+        var pageSize = PageSize.FromRequested(request.Limit);
+
+        // Cursor parsing must be ROP, not throwing (Cookbook Recipe 3 §352). Hand-rolling
+        // Guid.Parse would throw on bad input and escape the handler as a 500; the
+        // CursorCodec path returns Error.InvalidInput(cursor.malformed) -> HTTP 422.
+        System.Guid? afterId = null;
+        if (request.Cursor is { } cursor)
+        {
+            var decoded = CursorCodec.TryDecode<System.Guid>(cursor, fieldName: "cursor");
+            if (!decoded.TryGetValue(out var id, out var cursorError))
+                return ValueTask.FromResult(Result.Fail<Page<Dinner>>(cursorError));
+            afterId = id;
+        }
+
+        var overFetched = _repo.GetPageForHost(request.HostId, pageSize, afterId);
+        var page = PageBuilder.FromOverFetch(overFetched, pageSize, d => d.Id.Value);
+        return ValueTask.FromResult(Result.Ok(page));
     }
 }

--- a/Application/src/Menus/Queries/ListMenusForHostQuery.cs
+++ b/Application/src/Menus/Queries/ListMenusForHostQuery.cs
@@ -1,0 +1,56 @@
+namespace BuberDinner.Application.Menus.Queries;
+
+using System.Threading;
+using System.Threading.Tasks;
+using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.Host.ValueObject;
+using BuberDinner.Domain.Menu;
+using Mediator;
+
+/// <summary>
+/// Lists menus owned by the supplied host with cursor-based pagination (Cookbook Recipe 3).
+/// Same shape as <see cref="Dinners.Queries.ListDinnersForHostQuery"/>.
+/// </summary>
+public sealed class ListMenusForHostQuery : IRequest<Result<Page<Menu>>>
+{
+    public HostId HostId { get; }
+    public Cursor? Cursor { get; }
+    public int? Limit { get; }
+
+    public ListMenusForHostQuery(HostId hostId, Cursor? cursor = null, int? limit = null)
+    {
+        HostId = hostId;
+        Cursor = cursor;
+        Limit = limit;
+    }
+}
+
+public sealed class ListMenusForHostQueryHandler
+    : IRequestHandler<ListMenusForHostQuery, Result<Page<Menu>>>
+{
+    private readonly IMenuRepository _repo;
+
+    public ListMenusForHostQueryHandler(IMenuRepository repo)
+    {
+        _repo = repo;
+    }
+
+    public ValueTask<Result<Page<Menu>>> Handle(
+        ListMenusForHostQuery request, CancellationToken cancellationToken)
+    {
+        var pageSize = PageSize.FromRequested(request.Limit);
+
+        System.Guid? afterId = null;
+        if (request.Cursor is { } cursor)
+        {
+            var decoded = CursorCodec.TryDecode<System.Guid>(cursor, fieldName: "cursor");
+            if (!decoded.TryGetValue(out var id, out var cursorError))
+                return ValueTask.FromResult(Result.Fail<Page<Menu>>(cursorError));
+            afterId = id;
+        }
+
+        var overFetched = _repo.GetPageForHost(request.HostId, pageSize, afterId);
+        var page = PageBuilder.FromOverFetch(overFetched, pageSize, m => m.Id.Value);
+        return ValueTask.FromResult(Result.Ok(page));
+    }
+}

--- a/Docs/PR3_PAGINATION.md
+++ b/Docs/PR3_PAGINATION.md
@@ -1,0 +1,221 @@
+# PR 3 — Cursor pagination on per-host list endpoints
+
+> *Third in the 5-PR showcase arc. PR 1 (#27) added ETag + resource auth; PR 2 (#28) added
+> the Dinner state machine + domain events. PR 3 plugs in Trellis's cursor-pagination
+> primitives — `Page<T>` / `PageSize` / `CursorCodec` / `PageBuilder.FromOverFetch` —
+> across both new list endpoints, sharing one wire envelope between them.*
+
+---
+
+## What this PR adds (at a glance)
+
+| Capability | Where | Cookbook |
+|---|---|---|
+| `GET /hosts/{hostId}/dinners?cursor=...&limit=...` | `DinnersController.ListDinners` | Recipe 3 |
+| `GET /hosts/{hostId}/menus?cursor=...&limit=...` (new endpoint) | `MenusController.ListMenus` | Recipe 3 |
+| Repository over-fetch primitive: `GetPageForHost(host, pageSize, afterId)` | `IDinnerRepository` + `IMenuRepository` + InMemory impls | — |
+| `ListDinnersForHostQuery(HostId, Cursor?, int?) : IRequest<Result<Page<Dinner>>>` | `Application/src/Dinners/Queries/` | Recipe 3 |
+| `ListMenusForHostQuery(HostId, Cursor?, int?) : IRequest<Result<Page<Menu>>>` | `Application/src/Menus/Queries/` | Recipe 3 |
+| Framework `PagedResponse<T>` envelope + RFC 8288 `Link: <…>; rel="next"` header | `Trellis.Asp.ToHttpResponseAsync<T, TBody>(nextUrlBuilder, body, …)` | Asp §86 |
+| Malformed cursor → 422 with `cursor.malformed` | `CursorCodec.TryDecode<Guid>` returns `Result.Fail` (ROP, no throw) | Recipe 3 §352 |
+
+## The handler in 15 lines
+
+```csharp
+public ValueTask<Result<Page<Dinner>>> Handle(
+    ListDinnersForHostQuery request, CancellationToken cancellationToken)
+{
+    var pageSize = PageSize.FromRequested(request.Limit);
+
+    System.Guid? afterId = null;
+    if (request.Cursor is { } cursor)
+    {
+        var decoded = CursorCodec.TryDecode<System.Guid>(cursor, fieldName: "cursor");
+        if (!decoded.TryGetValue(out var id, out var cursorError))
+            return ValueTask.FromResult(Result.Fail<Page<Dinner>>(cursorError));
+        afterId = id;
+    }
+
+    var overFetched = _repo.GetPageForHost(request.HostId, pageSize, afterId);
+    var page = PageBuilder.FromOverFetch(overFetched, pageSize, d => d.Id.Value);
+    return ValueTask.FromResult(Result.Ok(page));
+}
+```
+
+Three Trellis pieces do all the work:
+
+| Primitive | What it owns |
+|---|---|
+| `PageSize.FromRequested(int?)` | Lenient parse: `null`/`<=0` → `PageSize.Default (50)`; preserves the caller's value as `RequestedLimit` and clamps `Applied` to `PageSize.Max (100)` so `WasCapped` round-trips. |
+| `CursorCodec.TryDecode<Guid>(cursor, "cursor")` | Base64 → typed Guid via railway. Bad input → `Error.InvalidInput(cursor.malformed)` → HTTP 422. Hand-rolling `Guid.Parse(cursor)` would throw and escape as a 500. |
+| `PageBuilder.FromOverFetch(items, pageSize, idSelector)` | Detects "is there a next page?" by counting the over-fetch (Applied+1) instead of issuing a separate COUNT. Returns a `Page<T>` with the right `Next` cursor and `DeliveredCount`. |
+
+## The controller in 12 lines
+
+```csharp
+[HttpGet]
+public async ValueTask<ActionResult<PagedResponse<DinnerResponse>>> ListDinners(
+    HostId hostId,
+    [FromQuery(Name = "cursor")] string? cursor,
+    [FromQuery(Name = "limit")]  int? limit,
+    CancellationToken cancellationToken)
+{
+    var basePath = $"/hosts/{hostId.Value}/dinners";
+    var apiVersion = HttpContext.GetRequestedApiVersion()?.ToString() ?? "2022-10-01";
+
+    return await _sender.Send(
+            new ListDinnersForHostQuery(hostId,
+                cursor is { Length: > 0 } token ? new Cursor(token) : (Cursor?)null,
+                limit),
+            cancellationToken)
+        .ToHttpResponseAsync(
+            nextUrlBuilder: (nextCursor, appliedLimit) =>
+                $"{basePath}?cursor={Uri.EscapeDataString(nextCursor.Token)}&limit={appliedLimit}&api-version={apiVersion}",
+            body: dinner => dinner.Adapt<DinnerResponse>())
+        .AsActionResultAsync<PagedResponse<DinnerResponse>>();
+}
+```
+
+`Trellis.Asp.ToHttpResponseAsync<T, TBody>(nextUrlBuilder, body, ...)` is the
+**paginated** overload — distinct from the plain `Result<T>` overload PR 2 uses. It:
+
+1. Projects each item through `body` (Mapster `Adapt<DinnerResponse>()`).
+2. Calls `nextUrlBuilder(cursor, appliedLimit)` to build absolute href URLs.
+3. Wraps everything in `PagedResponse<TResponse>(items, next, previous, requestedLimit, appliedLimit, deliveredCount, wasCapped)`.
+4. Emits the RFC 8288 `Link: <href>; rel="next"` header when `Page.Next` is non-null.
+
+`ListMenusForHostQuery` + `MenusController.ListMenus` mirror the shape exactly so the wire
+contract is identical across both endpoints — once a client knows how to page dinners, it
+knows how to page menus.
+
+## The wire dump (verified end-to-end)
+
+```http
+# Page 1 — no cursor.
+GET /hosts/{H}/dinners?api-version=2022-10-01&limit=5
+
+HTTP/1.1 200 OK
+Link: </hosts/{H}/dinners?cursor=MDE5ZTk2NjctMTQxZi03ZmQ1...&limit=5&api-version=2022-10-01>; rel="next"
+Content-Type: application/json
+{
+  "items":  [ ... 5 ... ],
+  "next":   { "cursor": "MDE5ZTk2NjctMTQxZi03ZmQ1...", "href": "/hosts/{H}/dinners?cursor=...&limit=5&api-version=2022-10-01" },
+  "previous": null,
+  "requestedLimit": 5, "appliedLimit": 5, "deliveredCount": 5, "wasCapped": false
+}
+
+# Page 2 — follow next.cursor; same shape; next is null on last page.
+GET /hosts/{H}/dinners?api-version=2022-10-01&limit=5&cursor=MDE5ZTk2NjctMTQxZi03ZmQ1...
+HTTP/1.1 200 OK
+{ "items": [ ... ], "next": null, "previous": null, ... }
+
+# Oversized limit — clamped to PageSize.Max.
+GET /hosts/{H}/dinners?api-version=2022-10-01&limit=500
+HTTP/1.1 200 OK
+{ "requestedLimit": 500, "appliedLimit": 100, "wasCapped": true, ... }
+
+# Malformed cursor — 422, NOT 500.
+GET /hosts/{H}/dinners?api-version=2022-10-01&cursor=NOT-A-VALID-CURSOR-!!!
+HTTP/1.1 422 Unprocessable Entity
+Content-Type: application/problem+json
+{ "status":422, "code":"invalid-input",
+  "errors":{"cursor":["Cursor is not a valid URL-safe base64 token."]} }
+```
+
+## Why over-fetch + `PageBuilder.FromOverFetch` instead of "load all + slice"
+
+The naive approach for an in-memory store would be `s_dinners.Where(...).Skip(N).Take(N)`.
+That doesn't translate to real persistence — every page would do a full scan and the
+"is there a next page?" check would need a `COUNT(*)` or a separate query. The over-fetch
+pattern (`Take(Applied + 1)`) detects "more rows exist" from the result itself:
+
+- Over-fetched **<= Applied** → this is the last page; `Next = null`.
+- Over-fetched **= Applied + 1** → trim to `Applied` items; `Next = Encode(lastItem.Id)`.
+
+This is the same shape EF Core's `ToPageAsync` uses internally per Cookbook Recipe 3. By
+exposing the over-fetched list on `IDinnerRepository.GetPageForHost(...)`, the in-memory
+showcase impl produces a `Page<T>` indistinguishable from one an EF Core impl would
+produce — when PR 4+ adds Cosmos repositories, only the Infrastructure layer changes.
+
+## Per-host scope is enforced at the repo, not in the handler
+
+```csharp
+public IReadOnlyList<Dinner> GetPageForHost(HostId hostId, PageSize pageSize, Guid? afterId)
+{
+    lock (s_lock)
+    {
+        IEnumerable<Dinner> source = s_dinners
+            .Where(d => d.HostId == hostId)            // <-- filter BEFORE the cursor seek
+            .OrderBy(d => d.Id.Value);
+        if (afterId is { } cursorId)
+            source = source.Where(d => d.Id.Value.CompareTo(cursorId) > 0);
+        return source.Take(pageSize.Applied + 1).ToList();
+    }
+}
+```
+
+The host filter is applied **before** the cursor seek so a caller cannot hand a stolen
+cursor from another host's page and slip it into their own list query — the seek is scoped
+to rows the caller already owns. Locked in by
+`Pagination_filters_by_host_so_one_hosts_cursor_does_not_leak_anothers_rows`.
+
+## Why V7 GUID ordering "just works"
+
+V7 GUIDs (`MenuId.NewUniqueV7()`, `DinnerId.NewUniqueV7()`) embed a millisecond timestamp
+in their first 6 bytes. `Guid.CompareTo` compares the first 4 bytes as a `uint32` and the
+next 2 as a `uint16` (each in the canonical struct layout used by the string form), so V7
+IDs sort **chronologically** under `OrderBy(d => d.Id.Value)` for the timestamp portion.
+Within the same millisecond, the random tail provides a stable secondary key. Net effect:
+the over-fetch pattern + Id-ordering produces pages in creation order without an explicit
+`CreatedAt` column.
+
+## Build, test, wire-verify
+
+- **0 warnings / 0 errors**
+- **Domain 31/31** (unchanged)
+- **Application 1/1** (unchanged)
+- **Api 51/51** (+7 new pagination tests, +1 existing `List_dinners_returns_only_host_owned_dinners` updated for the new envelope)
+
+Wire scenarios covered by `PaginationTests`:
+- Multi-page traversal, every id unique, ascending order, last page `Next = null`
+- RFC 8288 `Link: <…>; rel="next"` header on intermediate pages
+- `?limit=500` → server clamps to 100, `wasCapped=true`
+- Malformed cursor → 422 with `cursor.malformed`
+- Omitted `?limit` → `RequestedLimit = AppliedLimit = 50` (`PageSize.Default`)
+- Same shape across `ListDinners` and `ListMenus`
+- Cross-host scoping at the repo (foreign cursors can't leak)
+
+## Files that show off the most
+
+| File | Why look here |
+|---|---|
+| `Application/src/Dinners/Queries/ListDinnersForHostQuery.cs` | The whole pagination handler — three Trellis primitives, no plumbing |
+| `Application/src/Menus/Queries/ListMenusForHostQuery.cs` | Identical structural pattern across two aggregates — proof the abstraction generalises |
+| `Api/src/2022-12-21/Controllers/DinnersController.cs` (ListDinners action) | `ToHttpResponseAsync<T, TBody>(nextUrlBuilder, body, …)` — one call emits envelope + Link header |
+| `Application/src/Abstractions/Persistence/IDinnerRepository.cs` | The over-fetch contract that any future EF/Cosmos impl plugs into |
+| `Infrastructure/src/Persistence/Memory/DinnerInMemoryRepository.cs` | Host-filter-first, then seek, then `Take(Applied + 1)` |
+| `Api/tests/2022-12-21/PaginationTests.cs` | Seven wire scenarios including cross-host scoping |
+| `Requests/Dinners/ListDinners-WithCursor.http` | Shows the continuation workflow |
+
+## What's NOT in this PR (deferred)
+
+- **`previous` cursor** — always `null`. Trellis ships forward-only seek today; reverse-seek
+  comes when the framework does.
+- **Total count** — deliberately absent from the envelope. Counting requires a separate
+  query and most paged APIs are better off without it (consumers that need totals can
+  page until `next = null`).
+- **ETag on list responses** — `WithETag(...)` on a paginated response is technically
+  supported by `HttpResponseOptionsBuilder<Page<T>>` but would only be meaningful with
+  a stable hash over the items + cursors. Deferred.
+- **`Page<T>` projection in handler vs controller** — the handler currently returns
+  `Result<Page<Dinner>>` (aggregate) and the controller's `body:` selector projects to
+  `DinnerResponse`. The cookbook Recipe 3 example projects in the handler via
+  `page.Map(...)`; both are valid — chose controller-side here to keep BuberDinner's
+  Mapster-at-the-boundary convention.
+- **Pagination on `GET /authentication` or `GET /hosts`** — no list endpoints exist for
+  those today; their list shapes will be designed alongside the use case in later PRs.
+
+## Roadmap remaining
+
+- **PR 4**: Bookings + idempotency (`UseTrellisIdempotency`) + multi-aggregate (Recipe 22)
+- **PR 5**: Reviews + `AddTrellisFluentValidation` at command boundary + `Trellis.Testing` + ServiceDefaults

--- a/Infrastructure/src/DependencyInjection.cs
+++ b/Infrastructure/src/DependencyInjection.cs
@@ -61,13 +61,17 @@ public static class DependencyInjection
         configuration.Bind(nameof(CosmosDbClientSettings), cosmosDbClientSettings);
         services.AddSingleton(CosmosClientFactory.InitializeCosmosClientInstance(cosmosDbClientSettings));
         services.AddScoped<IRepository<User>, UserCosmosDbRepository>();
-        services.AddScoped<IRepository<Menu>, MenuCosmosDbRepository>();
-        // TODO: replace with HostCosmosDbRepository / MenuCosmosDbRepository (paginated) /
-        // DinnerCosmosDbRepository when they ship. Until then, fall back to in-memory so a
-        // Cosmos-configured deploy doesn't crash on POST /hosts, PUT .../menus/..., or the
-        // paginated list/dinner endpoints. Tracked alongside the broader 5-PR roadmap.
+        // TODO: replace with HostCosmosDbRepository / paginated MenuCosmosDbRepository (implements
+        // IMenuRepository) / DinnerCosmosDbRepository when they ship. Until then, fall back to
+        // in-memory so a Cosmos-configured deploy doesn't crash on POST /hosts, the paginated
+        // GET /menus / GET /dinners, or any Dinner state-transition. CRITICAL: both
+        // IRepository<TAggregate> AND the typed sub-interface (IMenuRepository / IDinnerRepository)
+        // must bind to the SAME scoped concrete instance — otherwise write and read flows hit
+        // different static stores and the list endpoints silently return empty after a successful
+        // create. Mirrors the InMemory branch wiring below.
         services.AddScoped<IRepository<HostEntity>, HostInMemoryRepository>();
         services.AddScoped<MenuInMemoryRepository>();
+        services.AddScoped<IRepository<Menu>>(sp => sp.GetRequiredService<MenuInMemoryRepository>());
         services.AddScoped<IMenuRepository>(sp => sp.GetRequiredService<MenuInMemoryRepository>());
         services.AddScoped<DinnerInMemoryRepository>();
         services.AddScoped<IRepository<DinnerEntity>>(sp => sp.GetRequiredService<DinnerInMemoryRepository>());

--- a/Infrastructure/src/DependencyInjection.cs
+++ b/Infrastructure/src/DependencyInjection.cs
@@ -62,14 +62,13 @@ public static class DependencyInjection
         services.AddSingleton(CosmosClientFactory.InitializeCosmosClientInstance(cosmosDbClientSettings));
         services.AddScoped<IRepository<User>, UserCosmosDbRepository>();
         services.AddScoped<IRepository<Menu>, MenuCosmosDbRepository>();
-        // TODO: replace with HostCosmosDbRepository when implemented. Until then, fall back to
-        // the in-memory implementation so a Cosmos-configured deploy doesn't crash on the first
-        // POST /hosts or PUT /hosts/.../menus/... (which loads the parent Host for
-        // IAuthorizeResource<Host>). Tracked alongside the broader 5-PR showcase roadmap.
+        // TODO: replace with HostCosmosDbRepository / MenuCosmosDbRepository (paginated) /
+        // DinnerCosmosDbRepository when they ship. Until then, fall back to in-memory so a
+        // Cosmos-configured deploy doesn't crash on POST /hosts, PUT .../menus/..., or the
+        // paginated list/dinner endpoints. Tracked alongside the broader 5-PR roadmap.
         services.AddScoped<IRepository<HostEntity>, HostInMemoryRepository>();
-        // TODO: replace with DinnerCosmosDbRepository when implemented. Same stop-gap rationale
-        // as Host above — Dinner aggregates land in the in-memory store regardless of the
-        // configured persistence mode until a Cosmos implementation ships.
+        services.AddScoped<MenuInMemoryRepository>();
+        services.AddScoped<IMenuRepository>(sp => sp.GetRequiredService<MenuInMemoryRepository>());
         services.AddScoped<DinnerInMemoryRepository>();
         services.AddScoped<IRepository<DinnerEntity>>(sp => sp.GetRequiredService<DinnerInMemoryRepository>());
         services.AddScoped<IDinnerRepository>(sp => sp.GetRequiredService<DinnerInMemoryRepository>());
@@ -79,7 +78,9 @@ public static class DependencyInjection
     private static IServiceCollection AddInMemoryDb(this IServiceCollection services)
     {
         services.AddScoped<IRepository<User>, UserInMemoryRepository>();
-        services.AddScoped<IRepository<Menu>, MenuInMemoryRepository>();
+        services.AddScoped<MenuInMemoryRepository>();
+        services.AddScoped<IRepository<Menu>>(sp => sp.GetRequiredService<MenuInMemoryRepository>());
+        services.AddScoped<IMenuRepository>(sp => sp.GetRequiredService<MenuInMemoryRepository>());
         services.AddScoped<IRepository<HostEntity>, HostInMemoryRepository>();
         services.AddScoped<DinnerInMemoryRepository>();
         services.AddScoped<IRepository<DinnerEntity>>(sp => sp.GetRequiredService<DinnerInMemoryRepository>());

--- a/Infrastructure/src/Persistence/Memory/DinnerInMemoryRepository.cs
+++ b/Infrastructure/src/Persistence/Memory/DinnerInMemoryRepository.cs
@@ -30,7 +30,27 @@ internal class DinnerInMemoryRepository : IDinnerRepository
     public IReadOnlyList<Dinner> GetForHost(HostId hostId)
     {
         lock (s_lock)
-            return s_dinners.Where(d => d.HostId == hostId).ToList();
+            return s_dinners.Where(d => d.HostId == hostId)
+                            .OrderBy(d => d.Id.Value)
+                            .ToList();
+    }
+
+    /// <summary>
+    /// Over-fetched, host-filtered, id-ordered slice for cursor pagination. Returns at most
+    /// <c>pageSize.Applied + 1</c> rows so <c>PageBuilder.FromOverFetch</c> can detect a next
+    /// page without an extra COUNT.
+    /// </summary>
+    public IReadOnlyList<Dinner> GetPageForHost(HostId hostId, Trellis.PageSize pageSize, System.Guid? afterId)
+    {
+        lock (s_lock)
+        {
+            IEnumerable<Dinner> source = s_dinners
+                .Where(d => d.HostId == hostId)
+                .OrderBy(d => d.Id.Value);
+            if (afterId is { } cursorId)
+                source = source.Where(d => d.Id.Value.CompareTo(cursorId) > 0);
+            return source.Take(pageSize.Applied + 1).ToList();
+        }
     }
 
     public ValueTask Add(Dinner dinner, CancellationToken cancellationToken)

--- a/Infrastructure/src/Persistence/Memory/MenuInMemoryRepository.cs
+++ b/Infrastructure/src/Persistence/Memory/MenuInMemoryRepository.cs
@@ -2,10 +2,12 @@ namespace BuberDinner.Infrastructure.Persistence.Memory;
 
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.Host.ValueObject;
 using BuberDinner.Domain.Menu;
 
-internal class MenuInMemoryRepository : IRepository<Menu>
+internal class MenuInMemoryRepository : IMenuRepository
 {
     private static readonly List<Menu> s_menus = new();
     // Parallel ETag store: in a real persistence layer the ETag is the row-version that the
@@ -18,6 +20,23 @@ internal class MenuInMemoryRepository : IRepository<Menu>
     {
         lock (s_lock)
             return s_menus.ToList();
+    }
+
+    /// <summary>
+    /// Over-fetched, host-filtered, id-ordered slice for cursor pagination. Same shape as
+    /// <see cref="DinnerInMemoryRepository.GetPageForHost"/>.
+    /// </summary>
+    public IReadOnlyList<Menu> GetPageForHost(HostId hostId, Trellis.PageSize pageSize, System.Guid? afterId)
+    {
+        lock (s_lock)
+        {
+            IEnumerable<Menu> source = s_menus
+                .Where(m => m.HostId == hostId)
+                .OrderBy(m => m.Id.Value);
+            if (afterId is { } cursorId)
+                source = source.Where(m => m.Id.Value.CompareTo(cursorId) > 0);
+            return source.Take(pageSize.Applied + 1).ToList();
+        }
     }
 
     public ValueTask Add(Menu menu, CancellationToken cancellationToken)

--- a/Requests/Dinners/ListDinners-MalformedCursor.http
+++ b/Requests/Dinners/ListDinners-MalformedCursor.http
@@ -1,0 +1,22 @@
+### Malformed cursor → 422 Unprocessable Entity with reason code `cursor.malformed`.
+### Server-side: `CursorCodec.TryDecode<Guid>` returns Result.Fail on bad base64, invalid
+### UTF-8, or unparseable Guid — the handler surfaces it through the standard Problem Details
+### shape per Cookbook Recipe 3 §352 ("Cursor parsing must be ROP, not throwing").
+
+@token = yourtoken
+@hostId = 019E955C-89A3-7F92-A289-35F8823BC135
+
+GET {{host}}/hosts/{{hostId}}/dinners?api-version=2022-10-01&cursor=NOT-A-VALID-CURSOR-!!!
+Authorization: Bearer {{token}}
+
+### Expected response:
+### HTTP/1.1 422 Unprocessable Entity
+### Content-Type: application/problem+json
+### {
+###   "type":"https://tools.ietf.org/html/rfc4918#section-11.2",
+###   "title":"One or more validation errors occurred.",
+###   "status":422,
+###   "errors":{"cursor":["Cursor is not a valid URL-safe base64 token."]},
+###   "code":"invalid-input",
+###   "kind":"unprocessable-content"
+### }

--- a/Requests/Dinners/ListDinners-OversizedLimit.http
+++ b/Requests/Dinners/ListDinners-OversizedLimit.http
@@ -1,0 +1,21 @@
+### Server caps the limit at `PageSize.Max = 100`. Asking for more is not an error —
+### the page returns `appliedLimit=100`, `requestedLimit=<what you asked>`, and
+### `wasCapped=true` so the client can see the clamp.
+
+@token = yourtoken
+@hostId = 019E955C-89A3-7F92-A289-35F8823BC135
+
+GET {{host}}/hosts/{{hostId}}/dinners?api-version=2022-10-01&limit=500
+Authorization: Bearer {{token}}
+
+### Expected response:
+### HTTP/1.1 200 OK
+### {
+###   "items": [ ... up to 100 entries ... ],
+###   "next": { ... } or null,
+###   "previous": null,
+###   "requestedLimit": 500,
+###   "appliedLimit": 100,
+###   "deliveredCount": <= 100,
+###   "wasCapped": true
+### }

--- a/Requests/Dinners/ListDinners-WithCursor.http
+++ b/Requests/Dinners/ListDinners-WithCursor.http
@@ -1,0 +1,25 @@
+### Follow the `next.cursor` returned by the previous page to fetch the next slice.
+### The cursor is opaque (URL-safe base64); paste the value from the previous response's
+### `next.cursor` field (or follow the `Link: <...>; rel="next"` header URL directly).
+
+@token = yourtoken
+@hostId = 019E955C-89A3-7F92-A289-35F8823BC135
+@cursor = MDE5ZTk2NjctMTQxZi03ZmQ1LTkxZjQtZWMzNzNkMDI2M2M4
+
+GET {{host}}/hosts/{{hostId}}/dinners?api-version=2022-10-01&limit=5&cursor={{cursor}}
+Authorization: Bearer {{token}}
+
+### Expected response (somewhere in the middle of a multi-page result set):
+### HTTP/1.1 200 OK
+### Link: </hosts/.../dinners?cursor=<next-base64>&limit=5&api-version=2022-10-01>; rel="next"
+### {
+###   "items": [ ... 5 entries ... ],
+###   "next":  { "cursor": "...", "href": "..." },
+###   "previous": null,
+###   "requestedLimit": 5,
+###   "appliedLimit": 5,
+###   "deliveredCount": 5,
+###   "wasCapped": false
+### }
+###
+### On the LAST page, `next` is null and no `Link: rel="next"` header is emitted.

--- a/Requests/Dinners/ListDinners.http
+++ b/Requests/Dinners/ListDinners.http
@@ -1,16 +1,26 @@
-### List all dinners owned by the route host. Simple (non-paginated) for PR 2 —
-### PR 3 will switch this to `Page<T>` + `Cursor` per Cookbook Recipe 3.
+### List dinners owned by the route host with cursor-based pagination (Cookbook Recipe 3).
+### Default page size (`PageSize.Default = 50`) when `?limit` is omitted; server caps at
+### `PageSize.Max = 100` (returns `wasCapped: true` when clamped).
 
 @token = yourtoken
 @hostId = 019E955C-89A3-7F92-A289-35F8823BC135
 
+### Page 1 — default limit, no cursor.
 GET {{host}}/hosts/{{hostId}}/dinners?api-version=2022-10-01
 Authorization: Bearer {{token}}
 
 ### Expected response:
 ### HTTP/1.1 200 OK
-### Content-Type: application/json
-### [
-###   { "id": "...", "name": "Brunch with friends", "status": "Upcoming", ... },
-###   { "id": "...", "name": "Another dinner",       "status": "Cancelled", ... }
-### ]
+### Link: </hosts/.../dinners?cursor=<base64>&limit=50&api-version=2022-10-01>; rel="next"
+### {
+###   "items": [ { "id": "...", "name": "...", "status": "...", ... }, ... ],
+###   "next": { "cursor": "MDE5ZTk2NjctMTQxZi03ZmQ1...", "href": "/hosts/.../dinners?cursor=...&limit=50&api-version=2022-10-01" },
+###   "previous": null,
+###   "requestedLimit": 50,
+###   "appliedLimit": 50,
+###   "deliveredCount": 50,
+###   "wasCapped": false
+### }
+###
+### `previous` is always null in PR 3 — forward-only seek per Cookbook Recipe 3 §350
+### (Trellis hasn't shipped reverse-seek yet).

--- a/Requests/Menus/ListMenus.http
+++ b/Requests/Menus/ListMenus.http
@@ -1,0 +1,21 @@
+### List menus owned by the route host with cursor-based pagination. Same envelope and
+### query parameters as GET /hosts/{hostId}/dinners (Cookbook Recipe 3).
+
+@token = yourtoken
+@hostId = 019E955C-89A3-7F92-A289-35F8823BC135
+
+GET {{host}}/hosts/{{hostId}}/menus?api-version=2022-10-01&limit=5
+Authorization: Bearer {{token}}
+
+### Expected response shape (identical to ListDinners.http):
+### HTTP/1.1 200 OK
+### Link: </hosts/.../menus?cursor=<base64>&limit=5&api-version=2022-10-01>; rel="next"
+### {
+###   "items": [ <MenuResponse>, ... ],
+###   "next":  { "cursor": "...", "href": "..." } or null,
+###   "previous": null,
+###   "requestedLimit": 5,
+###   "appliedLimit": 5,
+###   "deliveredCount": 5,
+###   "wasCapped": false
+### }


### PR DESCRIPTION
# PR 3 — Cursor pagination on per-host list endpoints

> *Third in the 5-PR showcase arc. PRs #27 (ETag + resource auth) and #28 (Dinner state
> machine + domain events) merged. PR 3 plugs in Trellis's cursor-pagination primitives —
> `Page<T>` / `PageSize` / `CursorCodec` / `PageBuilder.FromOverFetch` — across both the
> Dinner and Menu list endpoints, sharing one wire envelope between them.*

## TL;DR

| What | Where | Cookbook |
|---|---|---|
| `GET /hosts/{hostId}/dinners?cursor=...&limit=...` | `DinnersController.ListDinners` | Recipe 3 |
| `GET /hosts/{hostId}/menus?cursor=...&limit=...` (new) | `MenusController.ListMenus` | Recipe 3 |
| `IDinnerRepository.GetPageForHost(host, pageSize, afterId)` + same on `IMenuRepository` | Application abstractions | — |
| `ListDinnersForHostQuery(HostId, Cursor?, int?) : IRequest<Result<Page<Dinner>>>` | Application | Recipe 3 |
| `Trellis.Asp.PagedResponse<T>` envelope + RFC 8288 `Link: <…>; rel="next"` | framework `ToHttpResponseAsync(nextUrlBuilder, body, …)` | Asp §86 |
| Malformed cursor → 422 with `cursor.malformed` | `CursorCodec.TryDecode<Guid>` returns `Result.Fail` (ROP, no throw) | Recipe 3 §352 |

## The whole handler in 15 lines

```csharp
public ValueTask<Result<Page<Dinner>>> Handle(
    ListDinnersForHostQuery request, CancellationToken cancellationToken)
{
    var pageSize = PageSize.FromRequested(request.Limit);

    Guid? afterId = null;
    if (request.Cursor is { } cursor)
    {
        var decoded = CursorCodec.TryDecode<Guid>(cursor, fieldName: "cursor");
        if (!decoded.TryGetValue(out var id, out var cursorError))
            return ValueTask.FromResult(Result.Fail<Page<Dinner>>(cursorError));
        afterId = id;
    }

    var overFetched = _repo.GetPageForHost(request.HostId, pageSize, afterId);
    var page = PageBuilder.FromOverFetch(overFetched, pageSize, d => d.Id.Value);
    return ValueTask.FromResult(Result.Ok(page));
}
```

Three Trellis primitives do all the work — `PageSize.FromRequested` (lenient parse + cap),
`CursorCodec.TryDecode<Guid>` (railway, not throwing), `PageBuilder.FromOverFetch` (detects
"next page exists" from `Take(Applied+1)` so no extra `COUNT(*)`).

## The wire dump (verified end-to-end with 12 dinners + 12 menus)

```http
# Page 1 — no cursor.
GET /hosts/{H}/dinners?api-version=2022-10-01&limit=5
HTTP/1.1 200 OK
Link: </hosts/{H}/dinners?cursor=MDE5ZTk2NjctMTQxZi03ZmQ1...&limit=5&api-version=2022-10-01>; rel="next"
{
  "items":  [ ... 5 ... ],
  "next":   { "cursor": "MDE5...", "href": "/hosts/.../dinners?cursor=...&limit=5&api-version=2022-10-01" },
  "previous": null,
  "requestedLimit": 5, "appliedLimit": 5, "deliveredCount": 5, "wasCapped": false
}

# Page 2 — follow next.cursor. Page 3 of a 12-row set has 2 items and next = null.

# Oversized limit — clamped to PageSize.Max.
GET .../dinners?limit=500
{ "requestedLimit": 500, "appliedLimit": 100, "wasCapped": true, ... }

# Malformed cursor — 422, NOT 500.
GET .../dinners?cursor=NOT-A-VALID-CURSOR-!!!
HTTP/1.1 422 Unprocessable Entity
{ "status":422, "code":"invalid-input",
  "errors":{"cursor":["Cursor is not a valid URL-safe base64 token."]} }

# Cross-host scoping — host A's cursor cannot leak host B's rows because the host filter
# is applied BEFORE the cursor seek inside the repo.
```

## Why this scales beyond the in-memory showcase

The repo primitive is **over-fetch by `Applied + 1`**, *not* `Skip(N).Take(N)`:

```csharp
public IReadOnlyList<Dinner> GetPageForHost(HostId hostId, PageSize pageSize, Guid? afterId)
{
    lock (s_lock)
    {
        IEnumerable<Dinner> source = s_dinners
            .Where(d => d.HostId == hostId)
            .OrderBy(d => d.Id.Value);
        if (afterId is { } cursorId)
            source = source.Where(d => d.Id.Value.CompareTo(cursorId) > 0);
        return source.Take(pageSize.Applied + 1).ToList();
    }
}
```

Same shape EF Core's `ToPageAsync` produces. When PR 4+ adds Cosmos repositories, only
Infrastructure changes — the Application and API layers don't notice.

V7 GUIDs (`MenuId.NewUniqueV7()`, `DinnerId.NewUniqueV7()`) sort chronologically under
`Guid.CompareTo` (timestamp in the first 6 bytes), so `OrderBy(d => d.Id.Value)` gives
creation order without a separate `CreatedAt` column.

## Commit walkthrough (5 commits)

| # | sha | Scope |
|---|---|---|
| 1 | `1eaa9f2` | `feat(infra)`: `GetPageForHost` on both repos + DI binding |
| 2 | `d47b2b4` | `feat(app)`: cursor pagination on both queries (Recipe 3) |
| 3 | `3c4514d` | `feat(api)`: paginated `GET /dinners` + new paginated `GET /menus` |
| 4 | `e8dad31` | `test(api)`: 7 pagination tests + envelope fix for PR 2 list test |
| 5 | `019eebb` | `docs`: `Docs/PR3_PAGINATION.md` + 4 `.http` files |

## Build, test

- **0 warnings / 0 errors**
- **Domain 31/31** (unchanged) · **Application 1/1** (unchanged) · **Api 51/51** (+7 new, +1 updated)
- Infrastructure 0/2 (live-Cosmos baseline, pre-existing)

7 wire scenarios covered by `PaginationTests`:
1. Multi-page traversal — every id unique, ascending, last page `Next = null`
2. RFC 8288 `Link: <…>; rel="next"` header
3. `?limit=500` → server clamps to 100, `wasCapped=true`
4. Malformed cursor → 422 with `cursor.malformed`
5. Omitted `?limit` → `RequestedLimit = AppliedLimit = 50` (`PageSize.Default`)
6. `ListMenus` envelope identical to `ListDinners`
7. Cross-host scoping — host A's cursor cannot leak host B's rows

## What's NOT in this PR (deferred)

- **`previous` cursor** — forward-only seek; reverse-seek lands when the framework does.
- **Total count** in the envelope — deliberately omitted; counting requires a separate query and most paged APIs are better off without it.
- **ETag on list responses** — possible via `WithETag` but requires a stable hash over items + cursors. Deferred.
- **Handler-side `page.Map(...)` projection** — kept BuberDinner's controller-side Mapster convention; Recipe 3 example projects in handler. Both are valid.

## Roadmap remaining

- **PR 4**: Bookings + idempotency (`UseTrellisIdempotency`) + multi-aggregate (Recipe 22)
- **PR 5**: Reviews + `AddTrellisFluentValidation` at command boundary + `Trellis.Testing` + ServiceDefaults
