### PR TITLE
feat: Reservations aggregate + IETF Idempotency-Key middleware + multi-aggregate fail-loud

### DIFF
--- a/Api/src/2022-12-21/Controllers/DinnersController.cs
+++ b/Api/src/2022-12-21/Controllers/DinnersController.cs
@@ -174,4 +174,38 @@ public class DinnersController : ControllerBase
                 body: dinner => dinner.Adapt<DinnerResponse>(),
                 configure: opts => opts.WithETag(dinner => EntityTagValue.Strong(dinner.ETag)))
             .AsActionResultAsync<DinnerResponse>();
+
+    /// <summary>
+    /// Paginated list of every reservation against the route dinner — the host's view of
+    /// who's coming. Gated by Host ownership (Cookbook Recipe 7) via
+    /// <see cref="Trellis.Authorization.IAuthorizeResource{T}"/> on the underlying query.
+    /// Defense-in-depth: handler additionally verifies the dinner belongs to the route host.
+    /// </summary>
+    [HttpGet("{dinnerId:DinnerId}/reservations")]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
+    public async ValueTask<ActionResult<PagedResponse<BuberDinner.Api._2022_12_21.Models.Reservations.ReservationResponse>>> ListReservationsForDinner(
+        HostId hostId,
+        DinnerId dinnerId,
+        [FromQuery(Name = "cursor")] string? cursor,
+        [FromQuery(Name = "limit")] int? limit,
+        CancellationToken cancellationToken)
+    {
+        var origin = $"{Request.Scheme}://{Request.Host}";
+        var basePath = $"{origin}/hosts/{hostId.Value}/dinners/{dinnerId.Value}/reservations";
+        var apiVersion = HttpContext.GetRequestedApiVersion()?.ToString() ?? "2022-10-01";
+
+        return await _sender.Send(
+                new BuberDinner.Application.Reservations.Queries.ListReservationsForDinnerQuery(
+                    hostId, dinnerId,
+                    cursor is { Length: > 0 } token ? new Cursor(token) : (Cursor?)null,
+                    limit),
+                cancellationToken)
+            .ToHttpResponseAsync(
+                nextUrlBuilder: (nextCursor, appliedLimit) =>
+                    $"{basePath}?cursor={Uri.EscapeDataString(nextCursor.Token)}&limit={appliedLimit}&api-version={apiVersion}",
+                body: reservation => reservation.Adapt<BuberDinner.Api._2022_12_21.Models.Reservations.ReservationResponse>())
+            .AsActionResultAsync<PagedResponse<BuberDinner.Api._2022_12_21.Models.Reservations.ReservationResponse>>();
+    }
 }

--- a/Api/src/2022-12-21/Controllers/ReservationsController.cs
+++ b/Api/src/2022-12-21/Controllers/ReservationsController.cs
@@ -1,0 +1,166 @@
+namespace BuberDinner._2022_12_21.Controllers;
+
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Asp.Versioning;
+using BuberDinner.Api._2022_12_21.Models.Reservations;
+using BuberDinner.Application.Reservations.Commands;
+using BuberDinner.Application.Reservations.Queries;
+using BuberDinner.Domain.Dinner.ValueObject;
+using BuberDinner.Domain.Reservation.Entities;
+using BuberDinner.Domain.Reservation.ValueObject;
+using BuberDinner.Domain.User.ValueObjects;
+using Mapster;
+using Mediator;
+using Microsoft.AspNetCore.Mvc;
+using Trellis;
+using Trellis.Asp;
+using Trellis.Asp.Idempotency;
+
+/// <summary>
+/// Reservation endpoints. The create endpoint opts into the IETF Idempotency-Key middleware
+/// (Cookbook Recipe 29) via <see cref="IdempotentAttribute"/> — a retry with the same
+/// <c>Idempotency-Key</c> header + same body returns the cached 201 byte-for-byte instead
+/// of creating a second reservation. Same key + different body → 422 fingerprint mismatch.
+/// </summary>
+[ApiVersion("2022-10-01")]
+[Route("reservations")]
+[Produces("application/json")]
+[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+public class ReservationsController : ControllerBase
+{
+    private readonly ISender _sender;
+
+    /// <summary>Initialises a new instance of <see cref="ReservationsController"/>.</summary>
+    public ReservationsController(ISender sender)
+    {
+        _sender = sender;
+    }
+
+    /// <summary>
+    /// Reserve a seat at a dinner. Idempotent via the <c>Idempotency-Key</c> header per
+    /// IETF draft-ietf-httpapi-idempotency-key-header. Recipe 22 fail-loud applies: the
+    /// handler returns 404 if the supplied DinnerId doesn't exist, and 422 if the dinner
+    /// is no longer in the <c>Upcoming</c> state.
+    /// </summary>
+    [HttpPost]
+    [Idempotent]
+    [Consumes("application/json")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
+    public async ValueTask<ActionResult<ReservationResponse>> CreateReservation(
+        [FromBody] CreateReservationRequest request,
+        CancellationToken cancellationToken)
+    {
+        var guestIdResult = ResolveCallerGuestId();
+        if (guestIdResult.IsFailure)
+            return Unauthorized();
+        var guestId = guestIdResult.GetValueOrThrow("guestId");
+
+        var dinnerIdResult = DinnerId.TryCreate(request.DinnerId);
+        if (dinnerIdResult.IsFailure)
+            return UnprocessableEntity(new { errors = new { dinnerId = new[] { "Invalid DinnerId." } } });
+        var dinnerId = dinnerIdResult.GetValueOrThrow("dinnerId");
+
+        var command = new CreateReservationCommand(dinnerId, guestId, request.GuestCount);
+        return await _sender.Send(command, cancellationToken)
+            .ToHttpResponseAsync(
+                body: reservation => reservation.Adapt<ReservationResponse>(),
+                configure: opts => opts
+                    .Created(reservation => $"/reservations/{reservation.Id.Value}")
+                    .WithETag(reservation => EntityTagValue.Strong(reservation.ETag)))
+            .AsActionResultAsync<ReservationResponse>();
+    }
+
+    /// <summary>Get a single reservation. Visible only to the owning guest.</summary>
+    [HttpGet("{reservationId:ReservationId}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async ValueTask<ActionResult<ReservationResponse>> GetReservation(
+        ReservationId reservationId, CancellationToken cancellationToken)
+    {
+        var guestIdResult = ResolveCallerGuestId();
+        if (guestIdResult.IsFailure)
+            return Unauthorized();
+        var guestId = guestIdResult.GetValueOrThrow("guestId");
+
+        return await _sender.Send(new GetReservationQuery(reservationId, guestId), cancellationToken)
+            .ToHttpResponseAsync(
+                body: reservation => reservation.Adapt<ReservationResponse>(),
+                configure: opts => opts
+                    .WithETag(reservation => EntityTagValue.Strong(reservation.ETag))
+                    .EvaluatePreconditions())
+            .AsActionResultAsync<ReservationResponse>();
+    }
+
+    /// <summary>Cancel an active reservation. Only the owning guest can cancel.</summary>
+    [HttpPost("{reservationId:ReservationId}/cancel")]
+    [Consumes("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
+    public async ValueTask<ActionResult<ReservationResponse>> CancelReservation(
+        ReservationId reservationId,
+        [FromBody] CancelReservationRequest request,
+        CancellationToken cancellationToken)
+    {
+        var guestIdResult = ResolveCallerGuestId();
+        if (guestIdResult.IsFailure)
+            return Unauthorized();
+        var guestId = guestIdResult.GetValueOrThrow("guestId");
+
+        var command = new CancelReservationCommand(reservationId, guestId, request.Reason ?? string.Empty);
+        return await _sender.Send(command, cancellationToken)
+            .ToHttpResponseAsync(
+                body: reservation => reservation.Adapt<ReservationResponse>(),
+                configure: opts => opts.WithETag(reservation => EntityTagValue.Strong(reservation.ETag)))
+            .AsActionResultAsync<ReservationResponse>();
+    }
+
+    /// <summary>
+    /// Paginated list of the calling guest's own reservations. Cursor + limit per Cookbook
+    /// Recipe 3 — same envelope shape as PR 3's other list endpoints.
+    /// </summary>
+    [HttpGet("mine")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
+    public async ValueTask<ActionResult<PagedResponse<ReservationResponse>>> ListMyReservations(
+        [FromQuery(Name = "cursor")] string? cursor,
+        [FromQuery(Name = "limit")] int? limit,
+        CancellationToken cancellationToken)
+    {
+        var guestIdResult = ResolveCallerGuestId();
+        if (guestIdResult.IsFailure)
+            return Unauthorized();
+        var guestId = guestIdResult.GetValueOrThrow("guestId");
+
+        var origin = $"{Request.Scheme}://{Request.Host}";
+        var basePath = $"{origin}/reservations/mine";
+        var apiVersion = HttpContext.GetRequestedApiVersion()?.ToString() ?? "2022-10-01";
+
+        return await _sender.Send(
+                new ListMyReservationsQuery(
+                    guestId,
+                    cursor is { Length: > 0 } token ? new Cursor(token) : (Cursor?)null,
+                    limit),
+                cancellationToken)
+            .ToHttpResponseAsync(
+                nextUrlBuilder: (nextCursor, appliedLimit) =>
+                    $"{basePath}?cursor={Uri.EscapeDataString(nextCursor.Token)}&limit={appliedLimit}&api-version={apiVersion}",
+                body: reservation => reservation.Adapt<ReservationResponse>())
+            .AsActionResultAsync<PagedResponse<ReservationResponse>>();
+    }
+
+    private Result<UserId> ResolveCallerGuestId()
+    {
+        var raw = HttpContext.User.FindFirst("sub")?.Value
+                  ?? HttpContext.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (string.IsNullOrEmpty(raw))
+            return Result.Fail<UserId>(new Error.AuthenticationRequired());
+        return UserId.TryCreate(raw);
+    }
+}

--- a/Api/src/2022-12-21/Controllers/ReservationsController.cs
+++ b/Api/src/2022-12-21/Controllers/ReservationsController.cs
@@ -50,6 +50,7 @@ public class ReservationsController : ControllerBase
     [Idempotent]
     [Consumes("application/json")]
     [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]   // [Idempotent] middleware → idempotency.key_required
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
     public async ValueTask<ActionResult<ReservationResponse>> CreateReservation(
@@ -77,6 +78,7 @@ public class ReservationsController : ControllerBase
     /// <summary>Get a single reservation. Visible only to the owning guest.</summary>
     [HttpGet("{reservationId:ReservationId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status304NotModified)]   // .EvaluatePreconditions() → If-None-Match match
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async ValueTask<ActionResult<ReservationResponse>> GetReservation(
         ReservationId reservationId, CancellationToken cancellationToken)

--- a/Api/src/2022-12-21/Controllers/ReservationsController.cs
+++ b/Api/src/2022-12-21/Controllers/ReservationsController.cs
@@ -20,12 +20,7 @@ using Trellis;
 using Trellis.Asp;
 using Trellis.Asp.Idempotency;
 
-/// <summary>
-/// Reservation endpoints. The create endpoint opts into the IETF Idempotency-Key middleware
-/// (Cookbook Recipe 29) via <see cref="IdempotentAttribute"/> — a retry with the same
-/// <c>Idempotency-Key</c> header + same body returns the cached 201 byte-for-byte instead
-/// of creating a second reservation. Same key + different body → 422 fingerprint mismatch.
-/// </summary>
+/// <summary>Reservation endpoints.</summary>
 [ApiVersion("2022-10-01")]
 [Route("reservations")]
 [Produces("application/json")]
@@ -34,23 +29,18 @@ public class ReservationsController : ControllerBase
 {
     private readonly ISender _sender;
 
-    /// <summary>Initialises a new instance of <see cref="ReservationsController"/>.</summary>
+    /// <summary>Initialises a new <see cref="ReservationsController"/>.</summary>
     public ReservationsController(ISender sender)
     {
         _sender = sender;
     }
 
-    /// <summary>
-    /// Reserve a seat at a dinner. Idempotent via the <c>Idempotency-Key</c> header per
-    /// IETF draft-ietf-httpapi-idempotency-key-header. Recipe 22 fail-loud applies: the
-    /// handler returns 404 if the supplied DinnerId doesn't exist, and 422 if the dinner
-    /// is no longer in the <c>Upcoming</c> state.
-    /// </summary>
+    /// <summary>Reserve a seat at a dinner. Idempotent via the Idempotency-Key header (Recipe 29).</summary>
     [HttpPost]
     [Idempotent]
     [Consumes("application/json")]
     [ProducesResponseType(StatusCodes.Status201Created)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]   // [Idempotent] middleware → idempotency.key_required
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
     public async ValueTask<ActionResult<ReservationResponse>> CreateReservation(
@@ -62,9 +52,6 @@ public class ReservationsController : ControllerBase
             return Unauthorized();
         var guestId = guestIdResult.GetValueOrThrow("guestId");
 
-        // Parse + send through one Result pipeline. A bad DinnerId surfaces as the framework's
-        // standard 422 Problem Details shape via ToHttpResponseAsync (consistent with
-        // ScheduleDinnerRequest, UpdateMenuRequest, etc.) — no hand-rolled error bodies.
         return await request.ToCreateReservationCommand(guestId)
             .BindAsync(command => _sender.Send(command, cancellationToken))
             .ToHttpResponseAsync(
@@ -78,7 +65,7 @@ public class ReservationsController : ControllerBase
     /// <summary>Get a single reservation. Visible only to the owning guest.</summary>
     [HttpGet("{reservationId:ReservationId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status304NotModified)]   // .EvaluatePreconditions() → If-None-Match match
+    [ProducesResponseType(StatusCodes.Status304NotModified)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async ValueTask<ActionResult<ReservationResponse>> GetReservation(
         ReservationId reservationId, CancellationToken cancellationToken)
@@ -121,10 +108,7 @@ public class ReservationsController : ControllerBase
             .AsActionResultAsync<ReservationResponse>();
     }
 
-    /// <summary>
-    /// Paginated list of the calling guest's own reservations. Cursor + limit per Cookbook
-    /// Recipe 3 — same envelope shape as PR 3's other list endpoints.
-    /// </summary>
+    /// <summary>Paginated list of the calling guest's own reservations.</summary>
     [HttpGet("mine")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]

--- a/Api/src/2022-12-21/Controllers/ReservationsController.cs
+++ b/Api/src/2022-12-21/Controllers/ReservationsController.cs
@@ -61,13 +61,11 @@ public class ReservationsController : ControllerBase
             return Unauthorized();
         var guestId = guestIdResult.GetValueOrThrow("guestId");
 
-        var dinnerIdResult = DinnerId.TryCreate(request.DinnerId);
-        if (dinnerIdResult.IsFailure)
-            return UnprocessableEntity(new { errors = new { dinnerId = new[] { "Invalid DinnerId." } } });
-        var dinnerId = dinnerIdResult.GetValueOrThrow("dinnerId");
-
-        var command = new CreateReservationCommand(dinnerId, guestId, request.GuestCount);
-        return await _sender.Send(command, cancellationToken)
+        // Parse + send through one Result pipeline. A bad DinnerId surfaces as the framework's
+        // standard 422 Problem Details shape via ToHttpResponseAsync (consistent with
+        // ScheduleDinnerRequest, UpdateMenuRequest, etc.) — no hand-rolled error bodies.
+        return await request.ToCreateReservationCommand(guestId)
+            .BindAsync(command => _sender.Send(command, cancellationToken))
             .ToHttpResponseAsync(
                 body: reservation => reservation.Adapt<ReservationResponse>(),
                 configure: opts => opts

--- a/Api/src/2022-12-21/Models/Reservations/ReservationDtos.cs
+++ b/Api/src/2022-12-21/Models/Reservations/ReservationDtos.cs
@@ -7,7 +7,7 @@ using BuberDinner.Domain.User.ValueObjects;
 using Mapster;
 using DinnerIdClass = BuberDinner.Domain.Dinner.ValueObject.DinnerId;
 
-/// <summary>Wire representation of a <see cref="Reservation"/>.</summary>
+/// <summary>Wire shape for a reservation.</summary>
 public record ReservationResponse(
     string Id,
     string DinnerId,
@@ -21,13 +21,7 @@ public record ReservationResponse(
 /// <summary>POST /reservations request body.</summary>
 public record CreateReservationRequest(string DinnerId, int GuestCount)
 {
-    /// <summary>
-    /// Lifts the request into a validated <see cref="CreateReservationCommand"/> using the
-    /// railway pipeline. A bad <see cref="DinnerId"/> surfaces as the framework's standard
-    /// 422 Problem Details shape (one FieldViolation per offending field) — same as every
-    /// other request DTO in the codebase. Hand-rolling the 422 body in the controller
-    /// would diverge from the Trellis problem-details contract.
-    /// </summary>
+    /// <summary>Lifts the request into a validated command via the Result pipeline.</summary>
     public Result<CreateReservationCommand> ToCreateReservationCommand(UserId guestUserId) =>
         DinnerIdClass.TryCreate(this.DinnerId, nameof(DinnerId))
             .Map(dinnerId => new CreateReservationCommand(dinnerId, guestUserId, this.GuestCount));
@@ -39,13 +33,11 @@ public record CancelReservationRequest(string Reason);
 /// <summary>Mapster registration for Reservation → ReservationResponse.</summary>
 public sealed class ReservationMappingConfig : IRegister
 {
-    /// <summary>Registers the <see cref="Reservation"/> → <see cref="ReservationResponse"/> mapping.</summary>
-    public void Register(TypeAdapterConfig config)
-    {
+    /// <inheritdoc />
+    public void Register(TypeAdapterConfig config) =>
         config.NewConfig<Reservation, ReservationResponse>()
             .Map(dest => dest.Id, src => src.Id.Value.ToString())
             .Map(dest => dest.DinnerId, src => src.DinnerId.Value.ToString())
             .Map(dest => dest.GuestUserId, src => src.GuestUserId.Value)
             .Map(dest => dest.Status, src => src.Status.Value);
-    }
 }

--- a/Api/src/2022-12-21/Models/Reservations/ReservationDtos.cs
+++ b/Api/src/2022-12-21/Models/Reservations/ReservationDtos.cs
@@ -1,0 +1,36 @@
+namespace BuberDinner.Api._2022_12_21.Models.Reservations;
+
+using System;
+using BuberDinner.Domain.Reservation.Entities;
+using Mapster;
+
+/// <summary>Wire representation of a <see cref="Reservation"/>.</summary>
+public record ReservationResponse(
+    string Id,
+    string DinnerId,
+    string GuestUserId,
+    int GuestCount,
+    string Status,
+    DateTimeOffset ReservedAt,
+    DateTimeOffset? CancelledAt,
+    string? CancellationReason);
+
+/// <summary>POST /reservations request body.</summary>
+public record CreateReservationRequest(string DinnerId, int GuestCount);
+
+/// <summary>POST /reservations/{id}/cancel request body.</summary>
+public record CancelReservationRequest(string Reason);
+
+/// <summary>Mapster registration for Reservation → ReservationResponse.</summary>
+public sealed class ReservationMappingConfig : IRegister
+{
+    /// <summary>Registers the <see cref="Reservation"/> → <see cref="ReservationResponse"/> mapping.</summary>
+    public void Register(TypeAdapterConfig config)
+    {
+        config.NewConfig<Reservation, ReservationResponse>()
+            .Map(dest => dest.Id, src => src.Id.Value.ToString())
+            .Map(dest => dest.DinnerId, src => src.DinnerId.Value.ToString())
+            .Map(dest => dest.GuestUserId, src => src.GuestUserId.Value)
+            .Map(dest => dest.Status, src => src.Status.Value);
+    }
+}

--- a/Api/src/2022-12-21/Models/Reservations/ReservationDtos.cs
+++ b/Api/src/2022-12-21/Models/Reservations/ReservationDtos.cs
@@ -1,8 +1,11 @@
 namespace BuberDinner.Api._2022_12_21.Models.Reservations;
 
 using System;
+using BuberDinner.Application.Reservations.Commands;
 using BuberDinner.Domain.Reservation.Entities;
+using BuberDinner.Domain.User.ValueObjects;
 using Mapster;
+using DinnerIdClass = BuberDinner.Domain.Dinner.ValueObject.DinnerId;
 
 /// <summary>Wire representation of a <see cref="Reservation"/>.</summary>
 public record ReservationResponse(
@@ -16,7 +19,19 @@ public record ReservationResponse(
     string? CancellationReason);
 
 /// <summary>POST /reservations request body.</summary>
-public record CreateReservationRequest(string DinnerId, int GuestCount);
+public record CreateReservationRequest(string DinnerId, int GuestCount)
+{
+    /// <summary>
+    /// Lifts the request into a validated <see cref="CreateReservationCommand"/> using the
+    /// railway pipeline. A bad <see cref="DinnerId"/> surfaces as the framework's standard
+    /// 422 Problem Details shape (one FieldViolation per offending field) — same as every
+    /// other request DTO in the codebase. Hand-rolling the 422 body in the controller
+    /// would diverge from the Trellis problem-details contract.
+    /// </summary>
+    public Result<CreateReservationCommand> ToCreateReservationCommand(UserId guestUserId) =>
+        DinnerIdClass.TryCreate(this.DinnerId, nameof(DinnerId))
+            .Map(dinnerId => new CreateReservationCommand(dinnerId, guestUserId, this.GuestCount));
+}
 
 /// <summary>POST /reservations/{id}/cancel request body.</summary>
 public record CancelReservationRequest(string Reason);

--- a/Api/src/DependencyInjection.cs
+++ b/Api/src/DependencyInjection.cs
@@ -4,17 +4,22 @@ using System.Reflection;
 using BuberDinner.Application.Dinners.Events;
 using BuberDinner.Application.Hosts.Authorization;
 using BuberDinner.Application.Menus.Commands;
+using BuberDinner.Application.Reservations.Events;
 using BuberDinner.Domain.Dinner.Events;
 using BuberDinner.Domain.Dinner.ValueObject;
 using BuberDinner.Domain.Host.ValueObject;
 using BuberDinner.Domain.Menu.ValueObject;
+using BuberDinner.Domain.Reservation.Events;
+using BuberDinner.Domain.Reservation.ValueObject;
 using Mapster;
 using MapsterMapper;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
+using Trellis.Asp;
 using Trellis.Asp.Authorization;
+using Trellis.Asp.Idempotency;
 using Trellis.Asp.Routing;
 using Trellis.Mediator;
 
@@ -26,10 +31,11 @@ internal static class DependencyInjection
         services.AddTrellisAspWithScalarValidation();
 
         // Scalar value-object route constraints — let MVC bind `{hostId:HostId}` / `{menuId:MenuId}`
-        // / `{dinnerId:DinnerId}` straight into typed VOs at the boundary.
+        // / `{dinnerId:DinnerId}` / `{reservationId:ReservationId}` straight into typed VOs at the boundary.
         services.AddTrellisRouteConstraint<HostId>(nameof(HostId));
         services.AddTrellisRouteConstraint<MenuId>(nameof(MenuId));
         services.AddTrellisRouteConstraint<DinnerId>(nameof(DinnerId));
+        services.AddTrellisRouteConstraint<ReservationId>(nameof(ReservationId));
 
         // Resource-based authorization wiring: ClaimsActorProvider reads the JWT `sub` claim
         // and the SharedResourceLoaderById<Host, HostId> in the Application assembly authorizes
@@ -47,6 +53,20 @@ internal static class DependencyInjection
         services.AddDomainEventHandler<DinnerStarted, LogDinnerStartedHandler>();
         services.AddDomainEventHandler<DinnerEnded, LogDinnerEndedHandler>();
         services.AddDomainEventHandler<DinnerCancelled, LogDinnerCancelledHandler>();
+        services.AddDomainEventHandler<ReservationCreated, LogReservationCreatedHandler>();
+        services.AddDomainEventHandler<ReservationCancelled, LogReservationCancelledHandler>();
+
+        // IETF Idempotency-Key middleware wiring (Cookbook Recipe 29). The attribute on
+        // ReservationsController.CreateReservation opts THAT endpoint into the middleware;
+        // every other endpoint is a no-op. The in-memory store is single-process only —
+        // production hosts behind a load balancer need an EF-backed implementation that
+        // honours the same CAS contract.
+        services.AddTrellisIdempotency(opts =>
+        {
+            opts.Ttl = TimeSpan.FromHours(24);
+            opts.MaxRequestBodyBytes = 256 * 1024;
+        });
+        services.AddInMemoryIdempotencyStore();
 
         // .NET 8 testable clock — handlers inject TimeProvider rather than DateTime.UtcNow so
         // tests can pin the clock via FakeTimeProvider (Cookbook Recipe 17 §1319).

--- a/Api/src/Program.cs
+++ b/Api/src/Program.cs
@@ -1,6 +1,7 @@
 ﻿using BuberDinner.Api;
 using BuberDinner.Application;
 using BuberDinner.Infrastructure;
+using Trellis.Asp.Idempotency;
 
 var builder = WebApplication.CreateBuilder(args);
 {
@@ -29,8 +30,15 @@ var app = builder.Build();
         });
     app.UseExceptionHandler("/error");
     app.UseHttpsRedirection();
+    app.UseRouting();
     app.UseAuthentication();
     app.UseAuthorization();
+    // Idempotency middleware MUST sit AFTER UseAuthentication/UseAuthorization so the default
+    // per-actor scope sees the authenticated Actor and partitions the store by it. Mounting
+    // before authentication would let every authenticated request fall back to the shared
+    // 'anonymous' scope, which can let different users collide on the same Idempotency-Key
+    // (trellis-api-asp.md:431).
+    app.UseTrellisIdempotency();
     app.MapControllers().RequireAuthorization();
     app.Run();
 }

--- a/Api/tests/2022-12-21/ReservationTests.cs
+++ b/Api/tests/2022-12-21/ReservationTests.cs
@@ -184,6 +184,44 @@ public class ReservationTests : IClassFixture<WebApplicationFactory<Program>>
         problem!.Code.Should().Be("idempotency.key_required");
     }
 
+    [Fact, Priority(5)]
+    public async Task CreateReservation_with_malformed_DinnerId_returns_422_via_Trellis_problem_details()
+    {
+        var guest = await NewGuestClientAsync();
+
+        var req = new HttpRequestMessage(HttpMethod.Post, $"reservations{ApiVersion}")
+        {
+            Content = JsonBody(new { dinnerId = "not-a-guid", guestCount = 1 }),
+        };
+        req.Headers.TryAddWithoutValidation("Idempotency-Key", Guid.NewGuid().ToString());
+        var response = await guest.client.SendAsync(req);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        // The Trellis problem-details contract — `errors` is a dictionary keyed by field name,
+        // NOT the hand-rolled { errors: { dinnerId: [...] } } shape the controller used to emit.
+        response.Content.Headers.ContentType!.ToString().Should().StartWith("application/problem+json");
+        var problem = await response.Content.ReadAsAsync<ProblemDetailsBody>();
+        problem!.Code.Should().Be("invalid-input");
+    }
+
+    [Fact, Priority(5)]
+    public async Task ListReservationsForDinner_with_missing_dinner_returns_404_without_misleading_host_detail()
+    {
+        var (hostClient, _, hostId, _, _) = await SeedHostAndDinnerAsync();
+        var phantomDinnerId = Guid.NewGuid().ToString();
+
+        var response = await hostClient.GetAsync(
+            $"hosts/{hostId}/dinners/{phantomDinnerId}/reservations{ApiVersion}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var problem = await response.Content.ReadAsAsync<ProblemDetailsBody>();
+        // If the dinner truly doesn't exist, the Detail must NOT claim "does not belong to
+        // the specified host" — that's the wrong-host case. Two different 404 reasons need
+        // two different Detail strings.
+        problem!.Detail.Should().NotContain("does not belong",
+            "missing dinner is a different case from wrong-host; Detail must not conflate them");
+    }
+
     // -------------------- helpers --------------------
 
     private async Task<(HttpClient hostClient, string hostToken, string hostId, string menuId, string dinnerId)>

--- a/Api/tests/2022-12-21/ReservationTests.cs
+++ b/Api/tests/2022-12-21/ReservationTests.cs
@@ -63,7 +63,7 @@ public class ReservationTests : IClassFixture<WebApplicationFactory<Program>>
     [Fact, Priority(5)]
     public async Task CreateReservation_against_InProgress_dinner_returns_422()
     {
-        var (hostClient, hostToken, hostId, _, dinnerId) = await SeedHostAndDinnerAsync();
+        var (hostClient, _, hostId, _, dinnerId) = await SeedHostAndDinnerAsync();
         // Host starts the dinner so it's no longer Upcoming.
         var startResponse = await hostClient.PostAsync(
             $"hosts/{hostId}/dinners/{dinnerId}/start{ApiVersion}", new StringContent("", Encoding.UTF8, "application/json"));

--- a/Api/tests/2022-12-21/ReservationTests.cs
+++ b/Api/tests/2022-12-21/ReservationTests.cs
@@ -1,0 +1,268 @@
+namespace BuberDinner.Api.Tests._2022_12_21;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit.Priority;
+
+/// <summary>
+/// End-to-end coverage for the Reservation endpoints — happy path, fail-loud-on-missing-dinner
+/// (Cookbook Recipe 22), the leak-shielded ownership check, and the IETF Idempotency-Key
+/// replay/mismatch contract (Cookbook Recipe 29).
+/// </summary>
+[TestCaseOrderer(PriorityOrderer.Name, PriorityOrderer.Assembly)]
+public class ReservationTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private const string ApiVersion = "?api-version=2022-10-01";
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public ReservationTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact, Priority(5)]
+    public async Task CreateReservation_returns_201_with_etag_and_location()
+    {
+        var (hostClient, _, hostId, _, dinnerId) = await SeedHostAndDinnerAsync();
+        var guest = await NewGuestClientAsync();
+
+        var response = await PostReservationAsync(guest.client, dinnerId, guestCount: 2);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.ETag.Should().NotBeNull();
+        response.Headers.Location.Should().NotBeNull();
+        response.Headers.Location!.OriginalString.Should().StartWith("/reservations/");
+        var body = await response.Content.ReadAsAsync<ReservationBody>();
+        body!.Status.Should().Be("Reserved");
+        body.GuestCount.Should().Be(2);
+        body.DinnerId.Should().Be(dinnerId);
+        body.GuestUserId.Should().Be(guest.userId);
+    }
+
+    [Fact, Priority(5)]
+    public async Task CreateReservation_against_missing_dinner_returns_404_per_Recipe_22_fail_loud()
+    {
+        var guest = await NewGuestClientAsync();
+        var phantomDinnerId = Guid.NewGuid().ToString();
+
+        var response = await PostReservationAsync(guest.client, phantomDinnerId, guestCount: 1);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var problem = await response.Content.ReadAsAsync<ProblemDetailsBody>();
+        problem!.Code.Should().Be("not-found");
+    }
+
+    [Fact, Priority(5)]
+    public async Task CreateReservation_against_InProgress_dinner_returns_422()
+    {
+        var (hostClient, hostToken, hostId, _, dinnerId) = await SeedHostAndDinnerAsync();
+        // Host starts the dinner so it's no longer Upcoming.
+        var startResponse = await hostClient.PostAsync(
+            $"hosts/{hostId}/dinners/{dinnerId}/start{ApiVersion}", new StringContent("", Encoding.UTF8, "application/json"));
+        startResponse.EnsureSuccessStatusCode();
+
+        var guest = await NewGuestClientAsync();
+        var response = await PostReservationAsync(guest.client, dinnerId, guestCount: 2);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        var problem = await response.Content.ReadAsAsync<ProblemDetailsWithRules>();
+        problem!.Rules.Should().NotBeNull().And.Subject!
+            .Should().ContainSingle().Which.Code.Should().Be("reservation.dinner-not-upcoming");
+    }
+
+    [Fact, Priority(5)]
+    public async Task Idempotency_replay_returns_cached_201_with_Idempotent_Replayed_header_and_no_double_booking()
+    {
+        var (_, _, _, _, dinnerId) = await SeedHostAndDinnerAsync();
+        var guest = await NewGuestClientAsync();
+        var key = Guid.NewGuid().ToString();
+
+        var first = await PostReservationAsync(guest.client, dinnerId, guestCount: 2, idempotencyKey: key);
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+        var firstBody = await first.Content.ReadAsAsync<ReservationBody>();
+
+        var replay = await PostReservationAsync(guest.client, dinnerId, guestCount: 2, idempotencyKey: key);
+        replay.StatusCode.Should().Be(HttpStatusCode.Created, "framework replays the original snapshot, including the status code");
+        replay.Headers.TryGetValues("Idempotent-Replayed", out var replayedValues).Should().BeTrue(
+            "framework adds the Idempotent-Replayed: true marker on cached responses");
+        replayedValues!.Single().Should().Be("true");
+        var replayBody = await replay.Content.ReadAsAsync<ReservationBody>();
+        replayBody!.Id.Should().Be(firstBody!.Id, "no double-booking — replay returns the original reservation id");
+
+        // Verify only ONE reservation actually exists in the guest's list.
+        var mine = await guest.client.GetAsync($"reservations/mine{ApiVersion}");
+        var page = await mine.Content.ReadAsAsync<MyReservationsPage>();
+        page!.Items.Count(r => r.Id == firstBody.Id).Should().Be(1,
+            "Idempotency-Key replay must NOT produce a second reservation row");
+    }
+
+    [Fact, Priority(5)]
+    public async Task Idempotency_same_key_different_body_returns_422_fingerprint_mismatch()
+    {
+        var (_, _, _, _, dinnerId) = await SeedHostAndDinnerAsync();
+        var guest = await NewGuestClientAsync();
+        var key = Guid.NewGuid().ToString();
+
+        var first = await PostReservationAsync(guest.client, dinnerId, guestCount: 2, idempotencyKey: key);
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var mutated = await PostReservationAsync(guest.client, dinnerId, guestCount: 5, idempotencyKey: key);
+
+        mutated.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity,
+            "framework rejects same-key + different-body so the client knows the key was reused with a mutated payload");
+    }
+
+    [Fact, Priority(5)]
+    public async Task Cross_guest_cancel_returns_404_NotFound_leak_shield()
+    {
+        var (_, _, _, _, dinnerId) = await SeedHostAndDinnerAsync();
+        var owner = await NewGuestClientAsync();
+        var first = await PostReservationAsync(owner.client, dinnerId, guestCount: 1);
+        var reservationId = (await first.Content.ReadAsAsync<ReservationBody>())!.Id;
+
+        var intruder = await NewGuestClientAsync();
+        var response = await intruder.client.PostAsync(
+            $"reservations/{reservationId}/cancel{ApiVersion}",
+            JsonBody(new { reason = "hack attempt" }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "ownership mismatches return NotFound (not Forbidden) to avoid leaking existence");
+    }
+
+    [Fact, Priority(5)]
+    public async Task Host_can_list_reservations_for_their_dinner_via_resource_auth()
+    {
+        var (hostClient, _, hostId, _, dinnerId) = await SeedHostAndDinnerAsync();
+        var guest = await NewGuestClientAsync();
+        await PostReservationAsync(guest.client, dinnerId, guestCount: 2);
+
+        var response = await hostClient.GetAsync($"hosts/{hostId}/dinners/{dinnerId}/reservations{ApiVersion}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var page = await response.Content.ReadAsAsync<MyReservationsPage>();
+        page!.Items.Should().HaveCount(1).And.OnlyContain(r => r.DinnerId == dinnerId);
+    }
+
+    [Fact, Priority(5)]
+    public async Task Foreign_host_cannot_list_reservations_for_anothers_dinner_returns_403()
+    {
+        var (_, _, ownerHostId, _, ownerDinnerId) = await SeedHostAndDinnerAsync();
+        var (foreignClient, _, _, _, _) = await SeedHostAndDinnerAsync();
+
+        var response = await foreignClient.GetAsync(
+            $"hosts/{ownerHostId}/dinners/{ownerDinnerId}/reservations{ApiVersion}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        var problem = await response.Content.ReadAsAsync<ProblemDetailsBody>();
+        problem!.Code.Should().Be("reservations.host.owner");
+    }
+
+    [Fact, Priority(5)]
+    public async Task CreateReservation_without_Idempotency_Key_returns_400_idempotency_key_required()
+    {
+        var (_, _, _, _, dinnerId) = await SeedHostAndDinnerAsync();
+        var guest = await NewGuestClientAsync();
+
+        // Hand-build the request to skip the helper's default-Guid header injection.
+        var req = new HttpRequestMessage(HttpMethod.Post, $"reservations{ApiVersion}")
+        {
+            Content = JsonBody(new { dinnerId, guestCount = 1 }),
+        };
+        var response = await guest.client.SendAsync(req);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            "[Idempotent] endpoints enforce the Idempotency-Key header at the middleware before the handler runs");
+        var problem = await response.Content.ReadAsAsync<ProblemDetailsBody>();
+        problem!.Code.Should().Be("idempotency.key_required");
+    }
+
+    // -------------------- helpers --------------------
+
+    private async Task<(HttpClient hostClient, string hostToken, string hostId, string menuId, string dinnerId)>
+        SeedHostAndDinnerAsync()
+    {
+        var client = _factory.CreateClient();
+        var userId = $"h_{Guid.NewGuid():N}".Substring(0, 14);
+        var token = await RegisterAsync(client, userId);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var hostResp = await client.PostAsync($"hosts{ApiVersion}", JsonBody(new { displayName = "PR4 Host" }));
+        var hostId = (await hostResp.Content.ReadAsAsync<IdOnly>())!.Id;
+
+        var menuResp = await client.PostAsync($"hosts/{hostId}/menus/create{ApiVersion}", JsonBody(new
+        {
+            name = "M",
+            description = "d",
+            sections = new[] { new { name = "s", description = "d", items = new[] { new { name = "i", description = "d" } } } }
+        }));
+        var menuId = (await menuResp.Content.ReadAsAsync<IdOnly>())!.Id;
+
+        var dinnerResp = await client.PostAsync($"hosts/{hostId}/dinners{ApiVersion}", JsonBody(new
+        {
+            name = "Dinner",
+            description = "d",
+            menuId,
+            startDateTime = "2026-07-01T18:00:00Z",
+            endDateTime = "2026-07-01T21:00:00Z",
+        }));
+        var dinnerId = (await dinnerResp.Content.ReadAsAsync<IdOnly>())!.Id;
+
+        return (client, token, hostId, menuId, dinnerId);
+    }
+
+    private async Task<(HttpClient client, string userId, string token)> NewGuestClientAsync()
+    {
+        var client = _factory.CreateClient();
+        var userId = $"g_{Guid.NewGuid():N}".Substring(0, 14);
+        var token = await RegisterAsync(client, userId);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return (client, userId, token);
+    }
+
+    private static async Task<string> RegisterAsync(HttpClient client, string userId)
+    {
+        var body = $$"""
+            { "userId":"{{userId}}", "firstName":"F", "lastName":"L",
+              "email":"{{userId}}@example.com", "password":"SecretP4$$word" }
+            """;
+        var resp = await client.PostAsync("authentication/register",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadAsAsync<TokenReply>())!.Token;
+    }
+
+    private static async Task<HttpResponseMessage> PostReservationAsync(
+        HttpClient client, string dinnerId, int guestCount, string? idempotencyKey = null)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, $"reservations{ApiVersion}")
+        {
+            Content = JsonBody(new { dinnerId, guestCount }),
+        };
+        // The [Idempotent] middleware enforces presence: a missing Idempotency-Key on an
+        // opted-in endpoint returns 400 with code 'idempotency.key_required'. Default to a
+        // fresh Guid so callers that don't care about replay still hit the success path.
+        req.Headers.TryAddWithoutValidation("Idempotency-Key", idempotencyKey ?? Guid.NewGuid().ToString());
+        return await client.SendAsync(req);
+    }
+
+    private static StringContent JsonBody(object payload) =>
+        new(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+    private sealed record TokenReply(string Token);
+    private sealed record IdOnly(string Id);
+    private sealed record ReservationBody(
+        string Id, string DinnerId, string GuestUserId, int GuestCount, string Status,
+        DateTimeOffset ReservedAt, DateTimeOffset? CancelledAt, string? CancellationReason);
+    private sealed record MyReservationsPage(List<ReservationBody> Items);
+    private sealed record ProblemDetailsBody(int Status, string? Code, string? Kind, string? Detail);
+    private sealed record ProblemDetailsWithRules(int Status, string? Code, List<RuleEntry>? Rules);
+    private sealed record RuleEntry(string Code, string? Detail);
+}

--- a/Application/src/Abstractions/Persistence/IReservationRepository.cs
+++ b/Application/src/Abstractions/Persistence/IReservationRepository.cs
@@ -5,22 +5,9 @@ using BuberDinner.Domain.Dinner.ValueObject;
 using BuberDinner.Domain.Reservation.Entities;
 using BuberDinner.Domain.User.ValueObjects;
 
-/// <summary>
-/// Reservation-specific repository surface. Adds two per-relationship paginated reads to
-/// the generic <see cref="IRepository{T}"/>: one scoped to a Dinner (host's view of who's
-/// coming), one scoped to a Guest (the guest's view of their own reservations).
-/// </summary>
 public interface IReservationRepository : IRepository<Reservation>
 {
-    /// <summary>
-    /// Over-fetched, dinner-filtered, id-ordered slice. Same shape as
-    /// <see cref="IDinnerRepository.GetPageForHost"/>. The host's view of dinner attendance.
-    /// </summary>
     IReadOnlyList<Reservation> GetPageForDinner(DinnerId dinnerId, Trellis.PageSize pageSize, System.Guid? afterId);
 
-    /// <summary>
-    /// Over-fetched, guest-filtered, id-ordered slice. The guest's view of their own
-    /// reservations across every dinner.
-    /// </summary>
     IReadOnlyList<Reservation> GetPageForGuest(UserId guestUserId, Trellis.PageSize pageSize, System.Guid? afterId);
 }

--- a/Application/src/Abstractions/Persistence/IReservationRepository.cs
+++ b/Application/src/Abstractions/Persistence/IReservationRepository.cs
@@ -1,0 +1,26 @@
+namespace BuberDinner.Application.Abstractions.Persistence;
+
+using System.Collections.Generic;
+using BuberDinner.Domain.Dinner.ValueObject;
+using BuberDinner.Domain.Reservation.Entities;
+using BuberDinner.Domain.User.ValueObjects;
+
+/// <summary>
+/// Reservation-specific repository surface. Adds two per-relationship paginated reads to
+/// the generic <see cref="IRepository{T}"/>: one scoped to a Dinner (host's view of who's
+/// coming), one scoped to a Guest (the guest's view of their own reservations).
+/// </summary>
+public interface IReservationRepository : IRepository<Reservation>
+{
+    /// <summary>
+    /// Over-fetched, dinner-filtered, id-ordered slice. Same shape as
+    /// <see cref="IDinnerRepository.GetPageForHost"/>. The host's view of dinner attendance.
+    /// </summary>
+    IReadOnlyList<Reservation> GetPageForDinner(DinnerId dinnerId, Trellis.PageSize pageSize, System.Guid? afterId);
+
+    /// <summary>
+    /// Over-fetched, guest-filtered, id-ordered slice. The guest's view of their own
+    /// reservations across every dinner.
+    /// </summary>
+    IReadOnlyList<Reservation> GetPageForGuest(UserId guestUserId, Trellis.PageSize pageSize, System.Guid? afterId);
+}

--- a/Application/src/Dinners/Commands/ScheduleDinnerCommandHandler.cs
+++ b/Application/src/Dinners/Commands/ScheduleDinnerCommandHandler.cs
@@ -32,12 +32,15 @@ public sealed class ScheduleDinnerCommandHandler : ICommandHandler<ScheduleDinne
 
     public async ValueTask<Result<Dinner>> Handle(ScheduleDinnerCommand request, CancellationToken cancellationToken)
     {
-        // Resource auth proves the caller owns the route Host. It does NOT prove the supplied
-        // MenuId exists or belongs to that host. Without this load, a host could schedule a
-        // dinner against another host's menu (cookbook Recipe 22 — fail-loud on missing related
-        // aggregates).
+        // Recipe 22 — fail-loud on missing related aggregate. Without this the create
+        // command would silently succeed against a non-existent menu, persisting an orphan
+        // dinner pointing at nothing. NotFound (not Forbidden) keeps existence private from
+        // the caller. The two cases — Menu missing vs Menu owned by another host — are
+        // detected separately so the Detail string accurately reflects which one fired.
         var menu = await _menuRepository.FindById(request.MenuId.Value.ToString(), cancellationToken);
-        if (menu is null || menu.HostId != request.HostId)
+        if (menu is null)
+            return Result.Fail<Dinner>(new Error.NotFound(ResourceRef.For<Menu>(request.MenuId)));
+        if (menu.HostId != request.HostId)
             return Result.Fail<Dinner>(new Error.NotFound(ResourceRef.For<Menu>(request.MenuId))
             {
                 Detail = "Menu does not belong to the specified host.",

--- a/Application/src/Reservations/Commands/CancelReservationCommand.cs
+++ b/Application/src/Reservations/Commands/CancelReservationCommand.cs
@@ -1,0 +1,68 @@
+namespace BuberDinner.Application.Reservations.Commands;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.Reservation.Entities;
+using BuberDinner.Domain.Reservation.ValueObject;
+using BuberDinner.Domain.User.ValueObjects;
+using Mediator;
+
+/// <summary>
+/// Cancels an active reservation. Authorisation is handled inside the handler (rather than
+/// via <see cref="Trellis.Authorization.IAuthorizeResource{T}"/>) because the resource the
+/// caller must own is the Reservation itself — keyed by <c>GuestUserId</c> — and the existing
+/// resource-auth machinery wires through Host-id parents. A future PR can switch this to a
+/// shared <c>SharedResourceLoaderById&lt;Reservation, ReservationId&gt;</c> + Actor.Id match.
+/// </summary>
+public sealed class CancelReservationCommand : ICommand<Result<Reservation>>
+{
+    public ReservationId ReservationId { get; }
+    public UserId CallerGuestUserId { get; }
+    public string Reason { get; }
+
+    public CancelReservationCommand(ReservationId reservationId, UserId callerGuestUserId, string reason)
+    {
+        ReservationId = reservationId;
+        CallerGuestUserId = callerGuestUserId;
+        Reason = reason;
+    }
+}
+
+public sealed class CancelReservationCommandHandler
+    : ICommandHandler<CancelReservationCommand, Result<Reservation>>
+{
+    private readonly IReservationRepository _repo;
+    private readonly TimeProvider _clock;
+
+    public CancelReservationCommandHandler(IReservationRepository repo, TimeProvider clock)
+    {
+        _repo = repo;
+        _clock = clock;
+    }
+
+    public async ValueTask<Result<Reservation>> Handle(
+        CancelReservationCommand request, CancellationToken cancellationToken)
+    {
+        var reservation = await _repo.FindById(request.ReservationId.Value.ToString(), cancellationToken);
+        if (reservation is null)
+            return Result.Fail<Reservation>(new Error.NotFound(ResourceRef.For<Reservation>(request.ReservationId)));
+
+        // Only the guest who created the reservation can cancel it. Mirrors the
+        // dinners.owner / menus.owner pattern from PR 1/2; uses NotFound (not Forbidden)
+        // to avoid leaking existence of reservations the caller doesn't own.
+        if (reservation.GuestUserId != request.CallerGuestUserId)
+            return Result.Fail<Reservation>(new Error.NotFound(ResourceRef.For<Reservation>(request.ReservationId))
+            {
+                Detail = "Reservation does not belong to the calling guest.",
+            });
+
+        var cancelResult = reservation.Cancel(request.Reason, _clock);
+        if (cancelResult.IsFailure)
+            return cancelResult;
+
+        await _repo.Update(reservation, cancellationToken);
+        return cancelResult;
+    }
+}

--- a/Application/src/Reservations/Commands/CancelReservationCommand.cs
+++ b/Application/src/Reservations/Commands/CancelReservationCommand.cs
@@ -9,13 +9,6 @@ using BuberDinner.Domain.Reservation.ValueObject;
 using BuberDinner.Domain.User.ValueObjects;
 using Mediator;
 
-/// <summary>
-/// Cancels an active reservation. Authorisation is handled inside the handler (rather than
-/// via <see cref="Trellis.Authorization.IAuthorizeResource{T}"/>) because the resource the
-/// caller must own is the Reservation itself — keyed by <c>GuestUserId</c> — and the existing
-/// resource-auth machinery wires through Host-id parents. A future PR can switch this to a
-/// shared <c>SharedResourceLoaderById&lt;Reservation, ReservationId&gt;</c> + Actor.Id match.
-/// </summary>
 public sealed class CancelReservationCommand : ICommand<Result<Reservation>>
 {
     public ReservationId ReservationId { get; }
@@ -43,26 +36,22 @@ public sealed class CancelReservationCommandHandler
     }
 
     public async ValueTask<Result<Reservation>> Handle(
-        CancelReservationCommand request, CancellationToken cancellationToken)
-    {
-        var reservation = await _repo.FindById(request.ReservationId.Value.ToString(), cancellationToken);
-        if (reservation is null)
-            return Result.Fail<Reservation>(new Error.NotFound(ResourceRef.For<Reservation>(request.ReservationId)));
+        CancelReservationCommand request, CancellationToken cancellationToken) =>
+        await LoadReservationOwnedByAsync(request.ReservationId, request.CallerGuestUserId, cancellationToken)
+            .BindAsync(reservation => reservation.Cancel(request.Reason, _clock))
+            .TapAsync(reservation => _repo.Update(reservation, cancellationToken));
 
-        // Only the guest who created the reservation can cancel it. Mirrors the
-        // dinners.owner / menus.owner pattern from PR 1/2; uses NotFound (not Forbidden)
-        // to avoid leaking existence of reservations the caller doesn't own.
-        if (reservation.GuestUserId != request.CallerGuestUserId)
-            return Result.Fail<Reservation>(new Error.NotFound(ResourceRef.For<Reservation>(request.ReservationId))
+    private async ValueTask<Result<Reservation>> LoadReservationOwnedByAsync(
+        ReservationId reservationId, UserId callerGuestUserId, CancellationToken cancellationToken)
+    {
+        var reservation = await _repo.FindById(reservationId.Value.ToString(), cancellationToken);
+        if (reservation is null)
+            return Result.Fail<Reservation>(new Error.NotFound(ResourceRef.For<Reservation>(reservationId)));
+        if (reservation.GuestUserId != callerGuestUserId)
+            return Result.Fail<Reservation>(new Error.NotFound(ResourceRef.For<Reservation>(reservationId))
             {
                 Detail = "Reservation does not belong to the calling guest.",
             });
-
-        var cancelResult = reservation.Cancel(request.Reason, _clock);
-        if (cancelResult.IsFailure)
-            return cancelResult;
-
-        await _repo.Update(reservation, cancellationToken);
-        return cancelResult;
+        return Result.Ok(reservation);
     }
 }

--- a/Application/src/Reservations/Commands/CancelReservationCommand.cs
+++ b/Application/src/Reservations/Commands/CancelReservationCommand.cs
@@ -42,16 +42,13 @@ public sealed class CancelReservationCommandHandler
             .TapAsync(reservation => _repo.Update(reservation, cancellationToken));
 
     private async ValueTask<Result<Reservation>> LoadReservationOwnedByAsync(
-        ReservationId reservationId, UserId callerGuestUserId, CancellationToken cancellationToken)
-    {
-        var reservation = await _repo.FindById(reservationId.Value.ToString(), cancellationToken);
-        if (reservation is null)
-            return Result.Fail<Reservation>(new Error.NotFound(ResourceRef.For<Reservation>(reservationId)));
-        if (reservation.GuestUserId != callerGuestUserId)
-            return Result.Fail<Reservation>(new Error.NotFound(ResourceRef.For<Reservation>(reservationId))
-            {
-                Detail = "Reservation does not belong to the calling guest.",
-            });
-        return Result.Ok(reservation);
-    }
+        ReservationId reservationId, UserId callerGuestUserId, CancellationToken cancellationToken) =>
+        (await _repo.FindById(reservationId.Value.ToString(), cancellationToken))
+            .ToResult(new Error.NotFound(ResourceRef.For<Reservation>(reservationId)))
+            .Ensure(
+                r => r.GuestUserId == callerGuestUserId,
+                new Error.NotFound(ResourceRef.For<Reservation>(reservationId))
+                {
+                    Detail = "Reservation does not belong to the calling guest.",
+                });
 }

--- a/Application/src/Reservations/Commands/CreateReservationCommand.cs
+++ b/Application/src/Reservations/Commands/CreateReservationCommand.cs
@@ -5,17 +5,6 @@ using BuberDinner.Domain.Reservation.Entities;
 using BuberDinner.Domain.User.ValueObjects;
 using Mediator;
 
-/// <summary>
-/// Creates a new reservation for the authenticated guest against the supplied dinner.
-/// </summary>
-/// <remarks>
-/// Implemented as <see cref="ICommand{TResponse}"/> (not <c>IRequest</c>) so the
-/// <c>DomainEventDispatchBehavior</c> pipeline picks up <c>ReservationCreated</c> and fans
-/// it out to every registered handler — same rationale as the Dinner commands in PR 2.
-/// Wrapped at the HTTP boundary by the IETF Idempotency-Key middleware
-/// (<c>[Idempotent]</c> on the controller action, per Cookbook Recipe 29) so a network
-/// retry with the same key + body returns the cached 201 instead of double-booking.
-/// </remarks>
 public sealed class CreateReservationCommand : ICommand<Result<Reservation>>
 {
     public DinnerId DinnerId { get; }

--- a/Application/src/Reservations/Commands/CreateReservationCommand.cs
+++ b/Application/src/Reservations/Commands/CreateReservationCommand.cs
@@ -1,0 +1,31 @@
+namespace BuberDinner.Application.Reservations.Commands;
+
+using BuberDinner.Domain.Dinner.ValueObject;
+using BuberDinner.Domain.Reservation.Entities;
+using BuberDinner.Domain.User.ValueObjects;
+using Mediator;
+
+/// <summary>
+/// Creates a new reservation for the authenticated guest against the supplied dinner.
+/// </summary>
+/// <remarks>
+/// Implemented as <see cref="ICommand{TResponse}"/> (not <c>IRequest</c>) so the
+/// <c>DomainEventDispatchBehavior</c> pipeline picks up <c>ReservationCreated</c> and fans
+/// it out to every registered handler — same rationale as the Dinner commands in PR 2.
+/// Wrapped at the HTTP boundary by the IETF Idempotency-Key middleware
+/// (<c>[Idempotent]</c> on the controller action, per Cookbook Recipe 29) so a network
+/// retry with the same key + body returns the cached 201 instead of double-booking.
+/// </remarks>
+public sealed class CreateReservationCommand : ICommand<Result<Reservation>>
+{
+    public DinnerId DinnerId { get; }
+    public UserId GuestUserId { get; }
+    public int GuestCount { get; }
+
+    public CreateReservationCommand(DinnerId dinnerId, UserId guestUserId, int guestCount)
+    {
+        DinnerId = dinnerId;
+        GuestUserId = guestUserId;
+        GuestCount = guestCount;
+    }
+}

--- a/Application/src/Reservations/Commands/CreateReservationCommandHandler.cs
+++ b/Application/src/Reservations/Commands/CreateReservationCommandHandler.cs
@@ -9,12 +9,6 @@ using BuberDinner.Domain.Dinner.ValueObject;
 using BuberDinner.Domain.Reservation.Entities;
 using Mediator;
 
-/// <summary>
-/// Handles <see cref="CreateReservationCommand"/>: loads the parent Dinner (fail-loud if
-/// missing per Cookbook Recipe 22), verifies it is still in <c>Upcoming</c>, builds the
-/// Reservation aggregate, and persists. The dispatch pipeline then publishes
-/// <c>ReservationCreated</c> after the handler returns successfully.
-/// </summary>
 public sealed class CreateReservationCommandHandler
     : ICommandHandler<CreateReservationCommand, Result<Reservation>>
 {
@@ -33,31 +27,22 @@ public sealed class CreateReservationCommandHandler
     }
 
     public async ValueTask<Result<Reservation>> Handle(
-        CreateReservationCommand request, CancellationToken cancellationToken)
+        CreateReservationCommand request, CancellationToken cancellationToken) =>
+        await LoadDinnerAsync(request.DinnerId, cancellationToken)
+            .EnsureAsync(
+                d => d.Status == DinnerStatus.Upcoming,
+                d => Error.InvalidInput.ForRule("reservation.dinner-not-upcoming",
+                    $"Cannot reserve against a dinner whose status is {d.Status.Value}."))
+            .BindAsync(_ => Reservation.TryCreate(
+                request.DinnerId, request.GuestUserId, request.GuestCount, _clock))
+            .TapAsync(reservation => _reservationRepository.Add(reservation, cancellationToken));
+
+    private async ValueTask<Result<Dinner>> LoadDinnerAsync(
+        DinnerId dinnerId, CancellationToken cancellationToken)
     {
-        // Recipe 22 — fail-loud on missing related aggregate. Without this the create
-        // command would silently succeed against a non-existent dinner, leaving an orphan
-        // reservation row pointing at nothing. NotFound (not Forbidden) keeps existence
-        // private from the caller.
-        var dinner = await _dinnerRepository.FindById(request.DinnerId.Value.ToString(), cancellationToken);
-        if (dinner is null)
-            return Result.Fail<Reservation>(new Error.NotFound(ResourceRef.For<Dinner>(request.DinnerId)));
-
-        // Capacity / state precondition: a reservation only makes sense on a dinner that's
-        // still in the future. Started / ended / cancelled dinners are 422, not 404 — the
-        // dinner exists, it just doesn't accept reservations any more.
-        if (dinner.Status != DinnerStatus.Upcoming)
-            return Result.Fail<Reservation>(
-                Error.InvalidInput.ForRule("reservation.dinner-not-upcoming",
-                    $"Cannot reserve against a dinner whose status is {dinner.Status.Value}."));
-
-        var reservationResult = Reservation.TryCreate(
-            request.DinnerId, request.GuestUserId, request.GuestCount, _clock);
-        if (reservationResult.IsFailure)
-            return reservationResult;
-        var reservation = reservationResult.GetValueOrThrow("reservation");
-
-        await _reservationRepository.Add(reservation, cancellationToken);
-        return Result.Ok(reservation);
+        var dinner = await _dinnerRepository.FindById(dinnerId.Value.ToString(), cancellationToken);
+        return dinner is null
+            ? Result.Fail<Dinner>(new Error.NotFound(ResourceRef.For<Dinner>(dinnerId)))
+            : Result.Ok(dinner);
     }
 }

--- a/Application/src/Reservations/Commands/CreateReservationCommandHandler.cs
+++ b/Application/src/Reservations/Commands/CreateReservationCommandHandler.cs
@@ -38,11 +38,7 @@ public sealed class CreateReservationCommandHandler
             .TapAsync(reservation => _reservationRepository.Add(reservation, cancellationToken));
 
     private async ValueTask<Result<Dinner>> LoadDinnerAsync(
-        DinnerId dinnerId, CancellationToken cancellationToken)
-    {
-        var dinner = await _dinnerRepository.FindById(dinnerId.Value.ToString(), cancellationToken);
-        return dinner is null
-            ? Result.Fail<Dinner>(new Error.NotFound(ResourceRef.For<Dinner>(dinnerId)))
-            : Result.Ok(dinner);
-    }
+        DinnerId dinnerId, CancellationToken cancellationToken) =>
+        (await _dinnerRepository.FindById(dinnerId.Value.ToString(), cancellationToken))
+            .ToResult(new Error.NotFound(ResourceRef.For<Dinner>(dinnerId)));
 }

--- a/Application/src/Reservations/Commands/CreateReservationCommandHandler.cs
+++ b/Application/src/Reservations/Commands/CreateReservationCommandHandler.cs
@@ -1,0 +1,63 @@
+namespace BuberDinner.Application.Reservations.Commands;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.Dinner.Entities;
+using BuberDinner.Domain.Dinner.ValueObject;
+using BuberDinner.Domain.Reservation.Entities;
+using Mediator;
+
+/// <summary>
+/// Handles <see cref="CreateReservationCommand"/>: loads the parent Dinner (fail-loud if
+/// missing per Cookbook Recipe 22), verifies it is still in <c>Upcoming</c>, builds the
+/// Reservation aggregate, and persists. The dispatch pipeline then publishes
+/// <c>ReservationCreated</c> after the handler returns successfully.
+/// </summary>
+public sealed class CreateReservationCommandHandler
+    : ICommandHandler<CreateReservationCommand, Result<Reservation>>
+{
+    private readonly IReservationRepository _reservationRepository;
+    private readonly IRepository<Dinner> _dinnerRepository;
+    private readonly TimeProvider _clock;
+
+    public CreateReservationCommandHandler(
+        IReservationRepository reservationRepository,
+        IRepository<Dinner> dinnerRepository,
+        TimeProvider clock)
+    {
+        _reservationRepository = reservationRepository;
+        _dinnerRepository = dinnerRepository;
+        _clock = clock;
+    }
+
+    public async ValueTask<Result<Reservation>> Handle(
+        CreateReservationCommand request, CancellationToken cancellationToken)
+    {
+        // Recipe 22 — fail-loud on missing related aggregate. Without this the create
+        // command would silently succeed against a non-existent dinner, leaving an orphan
+        // reservation row pointing at nothing. NotFound (not Forbidden) keeps existence
+        // private from the caller.
+        var dinner = await _dinnerRepository.FindById(request.DinnerId.Value.ToString(), cancellationToken);
+        if (dinner is null)
+            return Result.Fail<Reservation>(new Error.NotFound(ResourceRef.For<Dinner>(request.DinnerId)));
+
+        // Capacity / state precondition: a reservation only makes sense on a dinner that's
+        // still in the future. Started / ended / cancelled dinners are 422, not 404 — the
+        // dinner exists, it just doesn't accept reservations any more.
+        if (dinner.Status != DinnerStatus.Upcoming)
+            return Result.Fail<Reservation>(
+                Error.InvalidInput.ForRule("reservation.dinner-not-upcoming",
+                    $"Cannot reserve against a dinner whose status is {dinner.Status.Value}."));
+
+        var reservationResult = Reservation.TryCreate(
+            request.DinnerId, request.GuestUserId, request.GuestCount, _clock);
+        if (reservationResult.IsFailure)
+            return reservationResult;
+        var reservation = reservationResult.GetValueOrThrow("reservation");
+
+        await _reservationRepository.Add(reservation, cancellationToken);
+        return Result.Ok(reservation);
+    }
+}

--- a/Application/src/Reservations/Events/ReservationEventHandlers.cs
+++ b/Application/src/Reservations/Events/ReservationEventHandlers.cs
@@ -6,8 +6,6 @@ using BuberDinner.Domain.Reservation.Events;
 using Microsoft.Extensions.Logging;
 using Trellis.Mediator;
 
-/// <summary>Logs <see cref="ReservationCreated"/> events. In a real deployment this would
-/// fan out to the host's notifications channel ("Alice booked 2 seats for your Brunch").</summary>
 public sealed class LogReservationCreatedHandler : IDomainEventHandler<ReservationCreated>
 {
     private readonly ILogger<LogReservationCreatedHandler> _logger;
@@ -27,7 +25,6 @@ public sealed class LogReservationCreatedHandler : IDomainEventHandler<Reservati
     }
 }
 
-/// <summary>Logs <see cref="ReservationCancelled"/> events, including the guest-supplied reason.</summary>
 public sealed class LogReservationCancelledHandler : IDomainEventHandler<ReservationCancelled>
 {
     private readonly ILogger<LogReservationCancelledHandler> _logger;

--- a/Application/src/Reservations/Events/ReservationEventHandlers.cs
+++ b/Application/src/Reservations/Events/ReservationEventHandlers.cs
@@ -1,0 +1,48 @@
+namespace BuberDinner.Application.Reservations.Events;
+
+using System.Threading;
+using System.Threading.Tasks;
+using BuberDinner.Domain.Reservation.Events;
+using Microsoft.Extensions.Logging;
+using Trellis.Mediator;
+
+/// <summary>Logs <see cref="ReservationCreated"/> events. In a real deployment this would
+/// fan out to the host's notifications channel ("Alice booked 2 seats for your Brunch").</summary>
+public sealed class LogReservationCreatedHandler : IDomainEventHandler<ReservationCreated>
+{
+    private readonly ILogger<LogReservationCreatedHandler> _logger;
+
+    public LogReservationCreatedHandler(ILogger<LogReservationCreatedHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public ValueTask HandleAsync(ReservationCreated notification, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Reservation {ReservationId} created by guest {GuestUserId} for dinner {DinnerId} ({GuestCount} seats) at {OccurredAt:o}",
+            notification.ReservationId.Value, notification.GuestUserId.Value,
+            notification.DinnerId.Value, notification.GuestCount, notification.OccurredAt);
+        return ValueTask.CompletedTask;
+    }
+}
+
+/// <summary>Logs <see cref="ReservationCancelled"/> events, including the guest-supplied reason.</summary>
+public sealed class LogReservationCancelledHandler : IDomainEventHandler<ReservationCancelled>
+{
+    private readonly ILogger<LogReservationCancelledHandler> _logger;
+
+    public LogReservationCancelledHandler(ILogger<LogReservationCancelledHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public ValueTask HandleAsync(ReservationCancelled notification, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Reservation {ReservationId} cancelled by guest {GuestUserId} at {OccurredAt:o} — reason: {Reason}",
+            notification.ReservationId.Value, notification.GuestUserId.Value,
+            notification.OccurredAt, notification.Reason);
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Application/src/Reservations/Queries/GetReservationQuery.cs
+++ b/Application/src/Reservations/Queries/GetReservationQuery.cs
@@ -29,16 +29,13 @@ public sealed class GetReservationQueryHandler : IRequestHandler<GetReservationQ
         _repo = repo;
     }
 
-    public async ValueTask<Result<Reservation>> Handle(GetReservationQuery request, CancellationToken cancellationToken)
-    {
-        var reservation = await _repo.FindById(request.ReservationId.Value.ToString(), cancellationToken);
-        if (reservation is null)
-            return Result.Fail<Reservation>(new Error.NotFound(ResourceRef.For<Reservation>(request.ReservationId)));
-        if (reservation.GuestUserId != request.CallerGuestUserId)
-            return Result.Fail<Reservation>(new Error.NotFound(ResourceRef.For<Reservation>(request.ReservationId))
-            {
-                Detail = "Reservation does not belong to the calling guest.",
-            });
-        return Result.Ok(reservation);
-    }
+    public async ValueTask<Result<Reservation>> Handle(GetReservationQuery request, CancellationToken cancellationToken) =>
+        (await _repo.FindById(request.ReservationId.Value.ToString(), cancellationToken))
+            .ToResult(new Error.NotFound(ResourceRef.For<Reservation>(request.ReservationId)))
+            .Ensure(
+                r => r.GuestUserId == request.CallerGuestUserId,
+                new Error.NotFound(ResourceRef.For<Reservation>(request.ReservationId))
+                {
+                    Detail = "Reservation does not belong to the calling guest.",
+                });
 }

--- a/Application/src/Reservations/Queries/GetReservationQuery.cs
+++ b/Application/src/Reservations/Queries/GetReservationQuery.cs
@@ -8,10 +8,6 @@ using BuberDinner.Domain.Reservation.ValueObject;
 using BuberDinner.Domain.User.ValueObjects;
 using Mediator;
 
-/// <summary>
-/// Get a single reservation. Visible only to its owning guest — same NotFound-leak-shield
-/// pattern as <c>GetMenuQuery</c> / <c>GetDinnerQuery</c>.
-/// </summary>
 public sealed class GetReservationQuery : IRequest<Result<Reservation>>
 {
     public ReservationId ReservationId { get; }

--- a/Application/src/Reservations/Queries/GetReservationQuery.cs
+++ b/Application/src/Reservations/Queries/GetReservationQuery.cs
@@ -1,0 +1,48 @@
+namespace BuberDinner.Application.Reservations.Queries;
+
+using System.Threading;
+using System.Threading.Tasks;
+using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.Reservation.Entities;
+using BuberDinner.Domain.Reservation.ValueObject;
+using BuberDinner.Domain.User.ValueObjects;
+using Mediator;
+
+/// <summary>
+/// Get a single reservation. Visible only to its owning guest — same NotFound-leak-shield
+/// pattern as <c>GetMenuQuery</c> / <c>GetDinnerQuery</c>.
+/// </summary>
+public sealed class GetReservationQuery : IRequest<Result<Reservation>>
+{
+    public ReservationId ReservationId { get; }
+    public UserId CallerGuestUserId { get; }
+
+    public GetReservationQuery(ReservationId reservationId, UserId callerGuestUserId)
+    {
+        ReservationId = reservationId;
+        CallerGuestUserId = callerGuestUserId;
+    }
+}
+
+public sealed class GetReservationQueryHandler : IRequestHandler<GetReservationQuery, Result<Reservation>>
+{
+    private readonly IReservationRepository _repo;
+
+    public GetReservationQueryHandler(IReservationRepository repo)
+    {
+        _repo = repo;
+    }
+
+    public async ValueTask<Result<Reservation>> Handle(GetReservationQuery request, CancellationToken cancellationToken)
+    {
+        var reservation = await _repo.FindById(request.ReservationId.Value.ToString(), cancellationToken);
+        if (reservation is null)
+            return Result.Fail<Reservation>(new Error.NotFound(ResourceRef.For<Reservation>(request.ReservationId)));
+        if (reservation.GuestUserId != request.CallerGuestUserId)
+            return Result.Fail<Reservation>(new Error.NotFound(ResourceRef.For<Reservation>(request.ReservationId))
+            {
+                Detail = "Reservation does not belong to the calling guest.",
+            });
+        return Result.Ok(reservation);
+    }
+}

--- a/Application/src/Reservations/Queries/ListMyReservationsQuery.cs
+++ b/Application/src/Reservations/Queries/ListMyReservationsQuery.cs
@@ -1,0 +1,56 @@
+namespace BuberDinner.Application.Reservations.Queries;
+
+using System.Threading;
+using System.Threading.Tasks;
+using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.Reservation.Entities;
+using BuberDinner.Domain.User.ValueObjects;
+using Mediator;
+
+/// <summary>
+/// Paginated list of the calling guest's own reservations across every dinner.
+/// Same cursor-pagination shape as PR 3's ListDinners / ListMenus.
+/// </summary>
+public sealed class ListMyReservationsQuery : IRequest<Result<Page<Reservation>>>
+{
+    public UserId CallerGuestUserId { get; }
+    public Cursor? Cursor { get; }
+    public int? Limit { get; }
+
+    public ListMyReservationsQuery(UserId callerGuestUserId, Cursor? cursor = null, int? limit = null)
+    {
+        CallerGuestUserId = callerGuestUserId;
+        Cursor = cursor;
+        Limit = limit;
+    }
+}
+
+public sealed class ListMyReservationsQueryHandler
+    : IRequestHandler<ListMyReservationsQuery, Result<Page<Reservation>>>
+{
+    private readonly IReservationRepository _repo;
+
+    public ListMyReservationsQueryHandler(IReservationRepository repo)
+    {
+        _repo = repo;
+    }
+
+    public ValueTask<Result<Page<Reservation>>> Handle(
+        ListMyReservationsQuery request, CancellationToken cancellationToken)
+    {
+        var pageSize = PageSize.FromRequested(request.Limit);
+
+        System.Guid? afterId = null;
+        if (request.Cursor is { } cursor)
+        {
+            var decoded = CursorCodec.TryDecode<System.Guid>(cursor, fieldName: "cursor");
+            if (!decoded.TryGetValue(out var id, out var cursorError))
+                return ValueTask.FromResult(Result.Fail<Page<Reservation>>(cursorError));
+            afterId = id;
+        }
+
+        var overFetched = _repo.GetPageForGuest(request.CallerGuestUserId, pageSize, afterId);
+        var page = PageBuilder.FromOverFetch(overFetched, pageSize, r => r.Id.Value);
+        return ValueTask.FromResult(Result.Ok(page));
+    }
+}

--- a/Application/src/Reservations/Queries/ListMyReservationsQuery.cs
+++ b/Application/src/Reservations/Queries/ListMyReservationsQuery.cs
@@ -7,10 +7,6 @@ using BuberDinner.Domain.Reservation.Entities;
 using BuberDinner.Domain.User.ValueObjects;
 using Mediator;
 
-/// <summary>
-/// Paginated list of the calling guest's own reservations across every dinner.
-/// Same cursor-pagination shape as PR 3's ListDinners / ListMenus.
-/// </summary>
 public sealed class ListMyReservationsQuery : IRequest<Result<Page<Reservation>>>
 {
     public UserId CallerGuestUserId { get; }

--- a/Application/src/Reservations/Queries/ListReservationsForDinnerQuery.cs
+++ b/Application/src/Reservations/Queries/ListReservationsForDinnerQuery.cs
@@ -1,0 +1,85 @@
+namespace BuberDinner.Application.Reservations.Queries;
+
+using System.Threading;
+using System.Threading.Tasks;
+using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.Dinner.ValueObject;
+using BuberDinner.Domain.Host.Entities;
+using BuberDinner.Domain.Host.ValueObject;
+using BuberDinner.Domain.Reservation.Entities;
+using Mediator;
+using Trellis.Authorization;
+
+/// <summary>
+/// Paginated list of reservations against a single dinner — the host's view of who's coming.
+/// Gated by Host ownership via <see cref="IAuthorizeResource{TResource}"/>: only the host
+/// that owns the dinner's parent host can list its reservations.
+/// </summary>
+public sealed class ListReservationsForDinnerQuery
+    : IRequest<Result<Page<Reservation>>>, IAuthorizeResource<Host>, IIdentifyResource<Host, HostId>
+{
+    public HostId HostId { get; }
+    public DinnerId DinnerId { get; }
+    public Cursor? Cursor { get; }
+    public int? Limit { get; }
+
+    public ListReservationsForDinnerQuery(HostId hostId, DinnerId dinnerId, Cursor? cursor = null, int? limit = null)
+    {
+        HostId = hostId;
+        DinnerId = dinnerId;
+        Cursor = cursor;
+        Limit = limit;
+    }
+
+    public HostId GetResourceId() => HostId;
+
+    public IResult Authorize(Actor actor, Host host) =>
+        host.OwnerId.Value == actor.Id.Value
+            ? Result.Ok()
+            : Result.Fail(new Error.Forbidden("reservations.host.owner", ResourceRef.For<Host>(HostId)));
+}
+
+public sealed class ListReservationsForDinnerQueryHandler
+    : IRequestHandler<ListReservationsForDinnerQuery, Result<Page<Reservation>>>
+{
+    private readonly IReservationRepository _reservationRepo;
+    private readonly IRepository<BuberDinner.Domain.Dinner.Entities.Dinner> _dinnerRepo;
+
+    public ListReservationsForDinnerQueryHandler(
+        IReservationRepository reservationRepo,
+        IRepository<BuberDinner.Domain.Dinner.Entities.Dinner> dinnerRepo)
+    {
+        _reservationRepo = reservationRepo;
+        _dinnerRepo = dinnerRepo;
+    }
+
+    public async ValueTask<Result<Page<Reservation>>> Handle(
+        ListReservationsForDinnerQuery request, CancellationToken cancellationToken)
+    {
+        // Defense-in-depth: route auth already proved the caller owns the route host.
+        // The dinner must additionally belong to that host (route-hierarchy check, mirrors
+        // the GetMenu/GetDinner pattern from PR 1/2). NotFound on mismatch keeps the leak
+        // surface consistent with the rest of the codebase.
+        var dinner = await _dinnerRepo.FindById(request.DinnerId.Value.ToString(), cancellationToken);
+        if (dinner is null || dinner.HostId != request.HostId)
+            return Result.Fail<Page<Reservation>>(new Error.NotFound(ResourceRef.For<BuberDinner.Domain.Dinner.Entities.Dinner>(request.DinnerId))
+            {
+                Detail = "Dinner does not belong to the specified host.",
+            });
+
+        var pageSize = PageSize.FromRequested(request.Limit);
+
+        System.Guid? afterId = null;
+        if (request.Cursor is { } cursor)
+        {
+            var decoded = CursorCodec.TryDecode<System.Guid>(cursor, fieldName: "cursor");
+            if (!decoded.TryGetValue(out var id, out var cursorError))
+                return Result.Fail<Page<Reservation>>(cursorError);
+            afterId = id;
+        }
+
+        var overFetched = _reservationRepo.GetPageForDinner(request.DinnerId, pageSize, afterId);
+        var page = PageBuilder.FromOverFetch(overFetched, pageSize, r => r.Id.Value);
+        return Result.Ok(page);
+    }
+}

--- a/Application/src/Reservations/Queries/ListReservationsForDinnerQuery.cs
+++ b/Application/src/Reservations/Queries/ListReservationsForDinnerQuery.cs
@@ -58,14 +58,20 @@ public sealed class ListReservationsForDinnerQueryHandler
     {
         // Defense-in-depth: route auth already proved the caller owns the route host.
         // The dinner must additionally belong to that host (route-hierarchy check, mirrors
-        // the GetMenu/GetDinner pattern from PR 1/2). NotFound on mismatch keeps the leak
-        // surface consistent with the rest of the codebase.
+        // the GetMenu/GetDinner pattern from PR 1/2). NotFound on either condition keeps
+        // the leak surface consistent with the rest of the codebase — but the two cases
+        // are detected separately so the Detail string accurately reflects which one fired
+        // (clients and log scrapers shouldn't see "does not belong" when the row is missing).
         var dinner = await _dinnerRepo.FindById(request.DinnerId.Value.ToString(), cancellationToken);
-        if (dinner is null || dinner.HostId != request.HostId)
-            return Result.Fail<Page<Reservation>>(new Error.NotFound(ResourceRef.For<BuberDinner.Domain.Dinner.Entities.Dinner>(request.DinnerId))
-            {
-                Detail = "Dinner does not belong to the specified host.",
-            });
+        if (dinner is null)
+            return Result.Fail<Page<Reservation>>(
+                new Error.NotFound(ResourceRef.For<BuberDinner.Domain.Dinner.Entities.Dinner>(request.DinnerId)));
+        if (dinner.HostId != request.HostId)
+            return Result.Fail<Page<Reservation>>(
+                new Error.NotFound(ResourceRef.For<BuberDinner.Domain.Dinner.Entities.Dinner>(request.DinnerId))
+                {
+                    Detail = "Dinner does not belong to the specified host.",
+                });
 
         var pageSize = PageSize.FromRequested(request.Limit);
 

--- a/Application/src/Reservations/Queries/ListReservationsForDinnerQuery.cs
+++ b/Application/src/Reservations/Queries/ListReservationsForDinnerQuery.cs
@@ -10,11 +10,6 @@ using BuberDinner.Domain.Reservation.Entities;
 using Mediator;
 using Trellis.Authorization;
 
-/// <summary>
-/// Paginated list of reservations against a single dinner — the host's view of who's coming.
-/// Gated by Host ownership via <see cref="IAuthorizeResource{TResource}"/>: only the host
-/// that owns the dinner's parent host can list its reservations.
-/// </summary>
 public sealed class ListReservationsForDinnerQuery
     : IRequest<Result<Page<Reservation>>>, IAuthorizeResource<Host>, IIdentifyResource<Host, HostId>
 {
@@ -56,12 +51,6 @@ public sealed class ListReservationsForDinnerQueryHandler
     public async ValueTask<Result<Page<Reservation>>> Handle(
         ListReservationsForDinnerQuery request, CancellationToken cancellationToken)
     {
-        // Defense-in-depth: route auth already proved the caller owns the route host.
-        // The dinner must additionally belong to that host (route-hierarchy check, mirrors
-        // the GetMenu/GetDinner pattern from PR 1/2). NotFound on either condition keeps
-        // the leak surface consistent with the rest of the codebase — but the two cases
-        // are detected separately so the Detail string accurately reflects which one fired
-        // (clients and log scrapers shouldn't see "does not belong" when the row is missing).
         var dinner = await _dinnerRepo.FindById(request.DinnerId.Value.ToString(), cancellationToken);
         if (dinner is null)
             return Result.Fail<Page<Reservation>>(

--- a/Docs/DomainModels/Aggregates.Reservation.md
+++ b/Docs/DomainModels/Aggregates.Reservation.md
@@ -1,0 +1,60 @@
+# Reservation aggregate
+
+A `Reservation` is a guest's claim to one or more seats at an upcoming `Dinner`.
+Lifecycle: `Reserved` → `Cancelled` (one-transition `LazyStateMachine<,>` per
+Cookbook Recipe 9). Owned by both the `Guest` (via `UserId`) and a `Dinner` (via
+`DinnerId`).
+
+### Status
+
+```text
+Reserved ──Cancel(reason)──▶ Cancelled    (terminal)
+```
+
+### Domain events
+
+| Event | When | Payload |
+|---|---|---|
+| `ReservationCreated`   | `TryCreate` succeeds              | `ReservationId, DinnerId, GuestUserId, GuestCount, OccurredAt` |
+| `ReservationCancelled` | `Cancel(reason, clock)` succeeds  | `ReservationId, DinnerId, GuestUserId, Reason, OccurredAt` |
+
+Per Cookbook Recipe 17, `OccurredAt` is the only timestamp on a domain event; the
+event type name carries the "Reserved"/"Cancelled" semantic. The aggregate also tracks
+`ReservedAt` and `CancelledAt` as projection-friendly fields (sourced from the same
+`clock.GetUtcNow()` that stamps the event's `OccurredAt`).
+
+### Wire shape
+
+```json
+{
+    "id": "019e9690-10f4-7584-8ab7-5af569f6983a",
+    "dinnerId": "019e9690-0fdc-7aa6-9807-7f0a56f08c42",
+    "guestUserId": "guest_ab989d50",
+    "guestCount": 2,
+    "status": "Reserved",
+    "reservedAt": "2026-06-05T06:54:44.4687691+00:00",
+    "cancelledAt": null,
+    "cancellationReason": null
+}
+```
+
+### Multi-aggregate orchestration (Cookbook Recipe 22)
+
+The create handler loads the parent `Dinner` first; a missing Dinner is `404`, not a
+silent orphan row. See `Application/src/Reservations/Commands/CreateReservationCommandHandler.cs`.
+
+### Idempotency (Cookbook Recipe 29)
+
+`POST /reservations` opts into the IETF `Idempotency-Key` middleware via the
+`[Idempotent]` attribute. A retry with the same key + same body returns the cached 201
+byte-for-byte with an extra `Idempotent-Replayed: true` header. Same key + different
+body → 422 (fingerprint mismatch). Missing key on the opted-in endpoint → 400 with
+`code: idempotency.key_required`.
+
+### Deferred to future PRs
+
+- **Capacity tracking on Dinner** (`MaxGuests` + `ReservedGuestCount`) — would let the
+  reservation handler also call `dinner.Reserve(guestCount)` and demonstrate the full
+  Recipe 25 two-pass validate-then-mutate pattern.
+- **Host cancel** — currently only the owning guest can cancel.
+- **`Bill`, `Guest`, `MenuReview` aggregates** — stubs in the design docs only.

--- a/Docs/PR4_RESERVATIONS_AND_IDEMPOTENCY.md
+++ b/Docs/PR4_RESERVATIONS_AND_IDEMPOTENCY.md
@@ -1,0 +1,189 @@
+# PR 4 — Reservations + IETF Idempotency-Key + multi-aggregate fail-loud
+
+> *Fourth in the 5-PR showcase arc. Adds the Reservation aggregate, opts the create endpoint
+> into the IETF `Idempotency-Key` middleware (Cookbook Recipe 29) so network retries can't
+> double-book, and demonstrates the Recipe 22 fail-loud-on-missing-related pattern via the
+> Dinner ↔ Reservation relationship.*
+
+## What this PR adds (at a glance)
+
+| Capability | Where | Cookbook |
+|---|---|---|
+| `Reservation` aggregate with one-transition `LazyStateMachine<,>` | `Domain/src/Reservation/Entities/Reservation.cs` | Recipe 9 |
+| `ReservationCreated` / `ReservationCancelled` events (`OccurredAt` only) | `Domain/src/Reservation/Events/` | Recipe 17 |
+| `POST /reservations` opted-in to IETF `Idempotency-Key` via `[Idempotent]` | `ReservationsController.CreateReservation` | Recipe 29 |
+| Recipe 22 fail-loud: `CreateReservationHandler` loads Dinner first; missing → 404 | `CreateReservationCommandHandler` | Recipe 22 |
+| `POST /reservations/{id}/cancel` with NotFound-leak-shielded ownership check | `CancelReservationCommandHandler` | — |
+| `GET /reservations/{id}` (owner-only) | `ReservationsController.GetReservation` | — |
+| `GET /reservations/mine` (paginated, guest view) | `ListMyReservationsQuery` + handler | Recipe 3 |
+| `GET /hosts/{hostId}/dinners/{dinnerId}/reservations` (paginated, host view, `IAuthorizeResource<Host>`) | `ListReservationsForDinnerQuery` + handler | Recipes 3 + 7 |
+| `services.AddTrellisIdempotency(...) + AddInMemoryIdempotencyStore() + app.UseTrellisIdempotency()` | `Api/src/DependencyInjection.cs`, `Program.cs` | Recipe 29 |
+
+## The idempotency contract (wire-verified)
+
+```http
+# 1. First POST with an Idempotency-Key → 201 + Location + ETag.
+POST /reservations HTTP/1.1
+Idempotency-Key: 12345678-1234-1234-1234-1234567890ab
+Content-Type: application/json
+{ "dinnerId": "...", "guestCount": 2 }
+
+HTTP/1.1 201 Created
+ETag: "0c3c7a80336049ae992bba0456801b05"
+Location: /reservations/019e9690-10f4-7584-8ab7-5af569f6983a
+{ "id": "019e9690-10f4-7584-8ab7-5af569f6983a", "status": "Reserved", ... }
+
+# 2. Retry — same key, same body → 201 + IDENTICAL body + Idempotent-Replayed: true.
+POST /reservations HTTP/1.1
+Idempotency-Key: 12345678-1234-1234-1234-1234567890ab
+{ "dinnerId": "...", "guestCount": 2 }
+
+HTTP/1.1 201 Created
+ETag: "0c3c7a80336049ae992bba0456801b05"   ← same
+Location: /reservations/019e9690-10f4-7584-8ab7-5af569f6983a   ← same id
+Idempotent-Replayed: true                                       ← framework's marker
+
+# 3. Same key, DIFFERENT body → 422 fingerprint mismatch.
+POST /reservations HTTP/1.1
+Idempotency-Key: 12345678-1234-1234-1234-1234567890ab
+{ "dinnerId": "...", "guestCount": 5 }       ← mutated
+
+HTTP/1.1 422 Unprocessable Entity
+
+# 4. Missing Idempotency-Key on an [Idempotent] endpoint → 400.
+POST /reservations HTTP/1.1
+{ "dinnerId": "...", "guestCount": 1 }
+
+HTTP/1.1 400 Bad Request
+{ "status":400, "code":"idempotency.key_required",
+  "detail":"This endpoint requires the Idempotency-Key header." }
+```
+
+The framework does all the work:
+
+- Reads the configured header (default `Idempotency-Key`, RFC 8941 `sf-string` subset).
+- Buffers the request body up to `MaxRequestBodyBytes`, computes SHA-256 over
+  `(method, path, normalized headers, body)`.
+- Resolves the scope through `DefaultIdempotencyScopeResolver` (per-actor, via the JWT
+  `sub` claim picked up by `ClaimsActorProvider`) so two different users with the same
+  Idempotency-Key partition the store separately.
+- On a successful response, snapshots `(status, headers, body)` against an
+  `InMemoryIdempotencyStore`.
+- On the next matching call within `Ttl` (24h here), replays the snapshot byte-for-byte
+  with an extra `Idempotent-Replayed: true` header.
+
+Per-actor scoping is critical — mounting `UseTrellisIdempotency()` BEFORE `UseAuthentication()`
+would let every authenticated request fall back to the shared `anonymous` scope, where
+different users could collide on the same key.
+
+## Recipe 22 fail-loud in action
+
+The Reservation handler:
+
+```csharp
+public async ValueTask<Result<Reservation>> Handle(
+    CreateReservationCommand request, CancellationToken cancellationToken)
+{
+    // Recipe 22 — load the related aggregate FIRST. If missing, fail-loud with NotFound
+    // so the post-condition "every reservation references a real dinner" holds.
+    var dinner = await _dinnerRepository.FindById(request.DinnerId.Value.ToString(), cancellationToken);
+    if (dinner is null)
+        return Result.Fail<Reservation>(new Error.NotFound(ResourceRef.For<Dinner>(request.DinnerId)));
+
+    // State precondition: only Upcoming dinners take reservations. Started / Ended /
+    // Cancelled → 422 (the dinner exists, it just doesn't accept new reservations).
+    if (dinner.Status != DinnerStatus.Upcoming)
+        return Result.Fail<Reservation>(
+            Error.InvalidInput.ForRule("reservation.dinner-not-upcoming",
+                $"Cannot reserve against a dinner whose status is {dinner.Status.Value}."));
+
+    var reservationResult = Reservation.TryCreate(request.DinnerId, request.GuestUserId,
+        request.GuestCount, _clock);
+    if (reservationResult.IsFailure) return reservationResult;
+
+    await _reservationRepository.Add(reservationResult.GetValueOrThrow("r"), cancellationToken);
+    return reservationResult;
+}
+```
+
+The anti-pattern would be: silently insert the reservation row and let it dangle. The
+fail-loud version surfaces the missing aggregate at the API boundary as a structured 404
+with the Dinner's `ResourceRef`, and the in-memory store never sees the orphan row.
+
+## Reservation state machine (one transition)
+
+```csharp
+private static void ConfigureMachine(StateMachine<ReservationStatus, ReservationTrigger> machine)
+{
+    machine.Configure(ReservationStatus.Reserved)
+           .Permit(ReservationTrigger.Cancel, ReservationStatus.Cancelled);
+    // Cancelled is terminal — cancelling twice returns 422 with state.machine.invalid.transition.
+}
+```
+
+One transition still earns the `LazyStateMachine<,>` framing — keeps the pattern
+consistent with Dinner from PR 2 so adding future transitions (`CheckedIn`, `NoShow`) is
+mechanical.
+
+## Authorization shape
+
+| Endpoint | Auth |
+|---|---|
+| `POST /reservations` | Authenticated; guest id is read from JWT `sub` claim |
+| `GET /reservations/{id}` | Authenticated; handler returns 404 if `reservation.GuestUserId != caller` (leak-shielded) |
+| `POST /reservations/{id}/cancel` | Same NotFound-leak-shield as above |
+| `GET /reservations/mine` | Authenticated; scoped to caller's UserId |
+| `GET /hosts/{hostId}/dinners/{dinnerId}/reservations` | Resource auth via `IAuthorizeResource<Host>` — only the host's owner; 403 with `code: "reservations.host.owner"` otherwise |
+
+The guest-owns-reservation check is intentionally in the handler (not via
+`IAuthorizeResource<Reservation>`) because the existing resource-auth machinery is keyed
+by Host id — wiring a new `SharedResourceLoaderById<Reservation, ReservationId>` would be
+mechanical follow-on work but isn't needed for PR 4 scope.
+
+## Build, test, wire-verify
+
+- **0 warnings / 0 errors**
+- **Domain 37/37** (+6 new Reservation tests including state-machine guards + blank-reason rejection)
+- **Application 1/1** (unchanged)
+- **Api 60/60** (+9 new Reservation integration tests including idempotency replay/mismatch/missing-key and cross-guest 404)
+
+Wire scenarios covered by `ReservationTests`:
+1. Happy create → 201 + ETag + Location
+2. POST against missing Dinner → 404 (Recipe 22)
+3. POST against InProgress Dinner → 422 with `reservation.dinner-not-upcoming`
+4. Idempotency replay → 201 + `Idempotent-Replayed: true` + no double-booking
+5. Same key + different body → 422 fingerprint mismatch
+6. Missing Idempotency-Key on `[Idempotent]` endpoint → 400 with `idempotency.key_required`
+7. Cross-guest cancel → 404 (leak-shield)
+8. Host can list reservations for their own dinner
+9. Foreign host listing another's dinner reservations → 403 with `reservations.host.owner`
+
+## Files that show off the most
+
+| File | Why look here |
+|---|---|
+| `Application/src/Reservations/Commands/CreateReservationCommandHandler.cs` | Recipe 22 fail-loud in one handler |
+| `Api/src/2022-12-21/Controllers/ReservationsController.cs` | `[Idempotent]` on the action + JWT `sub`-claim → `UserId` mapping |
+| `Api/src/DependencyInjection.cs` | `AddTrellisIdempotency(opts => { ... }) + AddInMemoryIdempotencyStore()` |
+| `Api/src/Program.cs` | `UseTrellisIdempotency()` MUST sit after `UseAuthentication`/`UseAuthorization` |
+| `Domain/src/Reservation/Entities/Reservation.cs` | Same `LazyStateMachine<,>` pattern from PR 2, one transition |
+| `Api/tests/2022-12-21/ReservationTests.cs` | Idempotency replay, fingerprint-mismatch, and missing-key contracts all asserted |
+
+## What's NOT in this PR (deferred)
+
+- **`MaxGuests` / capacity tracking on Dinner** — would have required updating
+  `Dinner.TryCreate` signature + breaking PR 2/3 tests. Recipe 22 is still showcased via
+  the existence check; capacity tracking can land in a later PR (or a dedicated PR 5).
+- **`IAuthorizeResource<Reservation>`** — guest-owns-reservation check is in the handler
+  for now. Wiring a new `SharedResourceLoaderById<Reservation, ReservationId>` is
+  mechanical follow-on.
+- **EF-backed `IIdempotencyStore`** — production-grade, multi-instance store. PR 4 ships
+  the in-memory dev/test store only.
+- **Reverse-seek (`Previous` cursor)** on list endpoints — still framework-deferred.
+- **`Trellis.Testing` matchers** for the wire assertions — coming in PR 5 alongside
+  ServiceDefaults + `AddTrellisFluentValidation`.
+
+## Roadmap remaining
+
+- **PR 5** (final): Reviews aggregate + `AddTrellisFluentValidation` at command boundary +
+  `Trellis.Testing` matchers + `Trellis.ServiceDefaults` composition root

--- a/Domain/src/Reservation/Entities/Reservation.cs
+++ b/Domain/src/Reservation/Entities/Reservation.cs
@@ -1,0 +1,119 @@
+namespace BuberDinner.Domain.Reservation.Entities;
+
+using System;
+using BuberDinner.Domain.Dinner.ValueObject;
+using BuberDinner.Domain.Reservation.Events;
+using BuberDinner.Domain.Reservation.ValueObject;
+using BuberDinner.Domain.User.ValueObjects;
+using FluentValidation;
+using Stateless;
+using Trellis.StateMachine;
+
+/// <summary>
+/// A reservation a guest holds against a <see cref="Dinner"/>. Lifecycle is two states
+/// (Reserved -> Cancelled) backed by the same Stateless / LazyStateMachine pattern PR 2 used
+/// for Dinner — a one-transition machine is still the right shape for consistency, and the
+/// pattern lets us add future transitions (e.g. CheckedIn, NoShow) without changing the
+/// surrounding handler chain.
+/// </summary>
+public sealed class Reservation : Aggregate<ReservationId>
+{
+    public DinnerId DinnerId { get; }
+    public UserId GuestUserId { get; }
+    public int GuestCount { get; }
+    public ReservationStatus Status { get; private set; }
+    public DateTimeOffset ReservedAt { get; }
+    public DateTimeOffset? CancelledAt { get; private set; }
+    public string? CancellationReason { get; private set; }
+
+    private readonly LazyStateMachine<ReservationStatus, ReservationTrigger> _machine;
+
+    /// <summary>
+    /// Creates a new reservation. Validates <paramref name="guestCount"/> is positive and
+    /// raises <see cref="ReservationCreated"/> for the dispatch pipeline.
+    /// </summary>
+    public static Result<Reservation> TryCreate(
+        DinnerId dinnerId,
+        UserId guestUserId,
+        int guestCount,
+        TimeProvider clock)
+    {
+        if (guestCount <= 0)
+            return Result.Fail<Reservation>(
+                Error.InvalidInput.ForField(nameof(GuestCount), "reservation.invalid.guest-count",
+                    "GuestCount must be positive."));
+
+        var reservation = new Reservation(
+            ReservationId.NewUniqueV7(), dinnerId, guestUserId, guestCount, clock.GetUtcNow());
+
+        var validation = s_validator.ValidateToResult(reservation);
+        if (validation.IsFailure)
+            return validation;
+
+        reservation.DomainEvents.Add(new ReservationCreated(
+            reservation.Id, reservation.DinnerId, reservation.GuestUserId,
+            reservation.GuestCount, reservation.ReservedAt));
+        return Result.Ok(reservation);
+    }
+
+    private Reservation(
+        ReservationId id,
+        DinnerId dinnerId,
+        UserId guestUserId,
+        int guestCount,
+        DateTimeOffset reservedAt)
+        : base(id)
+    {
+        DinnerId = dinnerId;
+        GuestUserId = guestUserId;
+        GuestCount = guestCount;
+        Status = ReservationStatus.Reserved;
+        ReservedAt = reservedAt;
+
+        _machine = new LazyStateMachine<ReservationStatus, ReservationTrigger>(
+            stateAccessor: () => Status,
+            stateMutator: s => Status = s,
+            configure: ConfigureMachine);
+    }
+
+    /// <summary>
+    /// Transitions the reservation from <see cref="ReservationStatus.Reserved"/> to
+    /// <see cref="ReservationStatus.Cancelled"/>, records the supplied reason, and raises
+    /// <see cref="ReservationCancelled"/>. Rejected (422 with reason code
+    /// <c>state.machine.invalid.transition</c>) when the reservation is already cancelled.
+    /// </summary>
+    public Result<Reservation> Cancel(string reason, TimeProvider clock)
+    {
+        if (string.IsNullOrWhiteSpace(reason))
+            return Result.Fail<Reservation>(
+                Error.InvalidInput.ForField(nameof(reason), "reservation.cancel.reason-required",
+                    "Cancellation reason must not be blank."));
+
+        return _machine.FireResult(ReservationTrigger.Cancel)
+            .Map(_ =>
+            {
+                var occurredAt = clock.GetUtcNow();
+                CancelledAt = occurredAt;
+                CancellationReason = reason;
+                DomainEvents.Add(new ReservationCancelled(
+                    Id, DinnerId, GuestUserId, reason, occurredAt));
+                return this;
+            });
+    }
+
+    private static void ConfigureMachine(StateMachine<ReservationStatus, ReservationTrigger> machine)
+    {
+        machine.Configure(ReservationStatus.Reserved)
+               .Permit(ReservationTrigger.Cancel, ReservationStatus.Cancelled);
+        // Cancelled is terminal.
+    }
+
+    static readonly InlineValidator<Reservation> s_validator = new()
+    {
+        v => v.RuleFor(x => x.Id).NotEmpty(),
+        v => v.RuleFor(x => x.DinnerId).NotEmpty(),
+        v => v.RuleFor(x => x.GuestUserId).NotEmpty(),
+        v => v.RuleFor(x => x.GuestCount).GreaterThan(0),
+        v => v.RuleFor(x => x.Status).NotEmpty(),
+    };
+}

--- a/Domain/src/Reservation/Entities/Reservation.cs
+++ b/Domain/src/Reservation/Entities/Reservation.cs
@@ -9,13 +9,6 @@ using FluentValidation;
 using Stateless;
 using Trellis.StateMachine;
 
-/// <summary>
-/// A reservation a guest holds against a <see cref="Dinner"/>. Lifecycle is two states
-/// (Reserved -> Cancelled) backed by the same Stateless / LazyStateMachine pattern PR 2 used
-/// for Dinner — a one-transition machine is still the right shape for consistency, and the
-/// pattern lets us add future transitions (e.g. CheckedIn, NoShow) without changing the
-/// surrounding handler chain.
-/// </summary>
 public sealed class Reservation : Aggregate<ReservationId>
 {
     public DinnerId DinnerId { get; }
@@ -28,10 +21,6 @@ public sealed class Reservation : Aggregate<ReservationId>
 
     private readonly LazyStateMachine<ReservationStatus, ReservationTrigger> _machine;
 
-    /// <summary>
-    /// Creates a new reservation. Validates <paramref name="guestCount"/> is positive and
-    /// raises <see cref="ReservationCreated"/> for the dispatch pipeline.
-    /// </summary>
     public static Result<Reservation> TryCreate(
         DinnerId dinnerId,
         UserId guestUserId,
@@ -76,12 +65,6 @@ public sealed class Reservation : Aggregate<ReservationId>
             configure: ConfigureMachine);
     }
 
-    /// <summary>
-    /// Transitions the reservation from <see cref="ReservationStatus.Reserved"/> to
-    /// <see cref="ReservationStatus.Cancelled"/>, records the supplied reason, and raises
-    /// <see cref="ReservationCancelled"/>. Rejected (422 with reason code
-    /// <c>state.machine.invalid.transition</c>) when the reservation is already cancelled.
-    /// </summary>
     public Result<Reservation> Cancel(string reason, TimeProvider clock)
     {
         if (string.IsNullOrWhiteSpace(reason))
@@ -101,12 +84,9 @@ public sealed class Reservation : Aggregate<ReservationId>
             });
     }
 
-    private static void ConfigureMachine(StateMachine<ReservationStatus, ReservationTrigger> machine)
-    {
+    private static void ConfigureMachine(StateMachine<ReservationStatus, ReservationTrigger> machine) =>
         machine.Configure(ReservationStatus.Reserved)
                .Permit(ReservationTrigger.Cancel, ReservationStatus.Cancelled);
-        // Cancelled is terminal.
-    }
 
     static readonly InlineValidator<Reservation> s_validator = new()
     {

--- a/Domain/src/Reservation/Events/ReservationEvents.cs
+++ b/Domain/src/Reservation/Events/ReservationEvents.cs
@@ -4,7 +4,6 @@ using BuberDinner.Domain.Dinner.ValueObject;
 using BuberDinner.Domain.Reservation.ValueObject;
 using BuberDinner.Domain.User.ValueObjects;
 
-/// <summary>Raised when a guest creates a new reservation against an upcoming dinner.</summary>
 public sealed record ReservationCreated(
     ReservationId ReservationId,
     DinnerId DinnerId,
@@ -12,7 +11,6 @@ public sealed record ReservationCreated(
     int GuestCount,
     DateTimeOffset OccurredAt) : IDomainEvent;
 
-/// <summary>Raised when a guest cancels a previously-active reservation.</summary>
 public sealed record ReservationCancelled(
     ReservationId ReservationId,
     DinnerId DinnerId,

--- a/Domain/src/Reservation/Events/ReservationEvents.cs
+++ b/Domain/src/Reservation/Events/ReservationEvents.cs
@@ -1,0 +1,21 @@
+namespace BuberDinner.Domain.Reservation.Events;
+
+using BuberDinner.Domain.Dinner.ValueObject;
+using BuberDinner.Domain.Reservation.ValueObject;
+using BuberDinner.Domain.User.ValueObjects;
+
+/// <summary>Raised when a guest creates a new reservation against an upcoming dinner.</summary>
+public sealed record ReservationCreated(
+    ReservationId ReservationId,
+    DinnerId DinnerId,
+    UserId GuestUserId,
+    int GuestCount,
+    DateTimeOffset OccurredAt) : IDomainEvent;
+
+/// <summary>Raised when a guest cancels a previously-active reservation.</summary>
+public sealed record ReservationCancelled(
+    ReservationId ReservationId,
+    DinnerId DinnerId,
+    UserId GuestUserId,
+    string Reason,
+    DateTimeOffset OccurredAt) : IDomainEvent;

--- a/Domain/src/Reservation/ValueObjects/ReservationId.cs
+++ b/Domain/src/Reservation/ValueObjects/ReservationId.cs
@@ -1,0 +1,5 @@
+namespace BuberDinner.Domain.Reservation.ValueObject;
+
+public partial class ReservationId : RequiredGuid<ReservationId>
+{
+}

--- a/Domain/src/Reservation/ValueObjects/ReservationStatus.cs
+++ b/Domain/src/Reservation/ValueObjects/ReservationStatus.cs
@@ -1,15 +1,8 @@
 namespace BuberDinner.Domain.Reservation.ValueObject;
 
-/// <summary>
-/// Lifecycle state of a <see cref="Reservation"/>. Two states only: a reservation is
-/// either active (<see cref="Reserved"/>) or has been called off (<see cref="Cancelled"/>).
-/// </summary>
 public partial class ReservationStatus : RequiredEnum<ReservationStatus>
 {
-    /// <summary>The reservation is active. The only state from which <c>Cancel</c> is permitted.</summary>
     public static readonly ReservationStatus Reserved = new();
-
-    /// <summary>Terminal — the guest called the reservation off before the dinner started.</summary>
     public static readonly ReservationStatus Cancelled = new();
 }
 

--- a/Domain/src/Reservation/ValueObjects/ReservationStatus.cs
+++ b/Domain/src/Reservation/ValueObjects/ReservationStatus.cs
@@ -1,0 +1,19 @@
+namespace BuberDinner.Domain.Reservation.ValueObject;
+
+/// <summary>
+/// Lifecycle state of a <see cref="Reservation"/>. Two states only: a reservation is
+/// either active (<see cref="Reserved"/>) or has been called off (<see cref="Cancelled"/>).
+/// </summary>
+public partial class ReservationStatus : RequiredEnum<ReservationStatus>
+{
+    /// <summary>The reservation is active. The only state from which <c>Cancel</c> is permitted.</summary>
+    public static readonly ReservationStatus Reserved = new();
+
+    /// <summary>Terminal — the guest called the reservation off before the dinner started.</summary>
+    public static readonly ReservationStatus Cancelled = new();
+}
+
+internal partial class ReservationTrigger : RequiredEnum<ReservationTrigger>
+{
+    public static readonly ReservationTrigger Cancel = new();
+}

--- a/Domain/tests/ReservationTests.cs
+++ b/Domain/tests/ReservationTests.cs
@@ -1,0 +1,108 @@
+namespace BuberDinner.Domain.Tests;
+
+using BuberDinner.Domain.Dinner.ValueObject;
+using BuberDinner.Domain.Reservation.Entities;
+using BuberDinner.Domain.Reservation.Events;
+using BuberDinner.Domain.Reservation.ValueObject;
+using BuberDinner.Domain.User.ValueObjects;
+using Microsoft.Extensions.Time.Testing;
+
+public class ReservationTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 7, 1, 18, 30, 0, TimeSpan.Zero);
+    private static readonly DinnerId Dinner = DinnerId.NewUniqueV7();
+    private static readonly UserId Guest = UserId.TryCreate("guest_user_42").GetValueOrThrow();
+
+    private static FakeTimeProvider Clock(DateTimeOffset? when = null) => new(when ?? Now);
+
+    private static Reservation NewReserved(TimeProvider clock) =>
+        Reservation.TryCreate(Dinner, Guest, guestCount: 2, clock).GetValueOrThrow();
+
+    [Fact]
+    public void TryCreate_succeeds_with_Reserved_status_and_raises_ReservationCreated()
+    {
+        var clock = Clock();
+        var r = NewReserved(clock);
+
+        r.Status.Should().Be(ReservationStatus.Reserved);
+        r.GuestCount.Should().Be(2);
+        r.GuestUserId.Should().Be(Guest);
+        r.DinnerId.Should().Be(Dinner);
+        r.ReservedAt.Should().Be(Now);
+        r.CancelledAt.Should().BeNull();
+        r.CancellationReason.Should().BeNull();
+
+        var ev = r.UncommittedEvents().Should().ContainSingle().Which.Should().BeOfType<ReservationCreated>().Subject;
+        ev.OccurredAt.Should().Be(Now);
+        ev.GuestCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void TryCreate_rejects_zero_guest_count()
+    {
+        var bad = Reservation.TryCreate(Dinner, Guest, guestCount: 0, Clock());
+        bad.IsFailure.Should().BeTrue();
+        var error = bad.Match(_ => null!, e => e).Should().BeOfType<Error.InvalidInput>().Subject;
+        error.Fields.Items.Should().ContainSingle()
+            .Which.ReasonCode.Should().Be("reservation.invalid.guest-count");
+    }
+
+    [Fact]
+    public void TryCreate_rejects_negative_guest_count()
+    {
+        var bad = Reservation.TryCreate(Dinner, Guest, guestCount: -1, Clock());
+        bad.IsFailure.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Cancel_succeeds_from_Reserved_and_raises_ReservationCancelled()
+    {
+        var clock = Clock();
+        var r = NewReserved(clock);
+        r.AcceptChanges();
+
+        clock.Advance(TimeSpan.FromHours(1));
+        var result = r.Cancel("Schedule conflict", clock);
+
+        result.IsSuccess.Should().BeTrue();
+        r.Status.Should().Be(ReservationStatus.Cancelled);
+        r.CancelledAt.Should().Be(Now.AddHours(1));
+        r.CancellationReason.Should().Be("Schedule conflict");
+        var ev = r.UncommittedEvents().Should().ContainSingle().Which.Should().BeOfType<ReservationCancelled>().Subject;
+        ev.Reason.Should().Be("Schedule conflict");
+        ev.OccurredAt.Should().Be(Now.AddHours(1));
+    }
+
+    [Fact]
+    public void Cancel_when_already_Cancelled_is_rejected_with_state_machine_reason_code()
+    {
+        var clock = Clock();
+        var r = NewReserved(clock);
+        r.Cancel("First", clock).GetValueOrThrow();
+        r.AcceptChanges();
+
+        var result = r.Cancel("Second", clock);
+
+        result.IsFailure.Should().BeTrue();
+        var error = result.Match(_ => null!, e => e).Should().BeOfType<Error.InvalidInput>().Subject;
+        error.Rules.Items.Should().ContainSingle()
+            .Which.ReasonCode.Should().Be("state.machine.invalid.transition");
+        r.CancellationReason.Should().Be("First", "rejected transitions must not overwrite prior state");
+    }
+
+    [Fact]
+    public void Cancel_rejects_blank_reason_before_consulting_state_machine()
+    {
+        var clock = Clock();
+        var r = NewReserved(clock);
+        r.AcceptChanges();
+
+        var result = r.Cancel("   ", clock);
+
+        result.IsFailure.Should().BeTrue();
+        var error = result.Match(_ => null!, e => e).Should().BeOfType<Error.InvalidInput>().Subject;
+        error.Fields.Items.Should().ContainSingle()
+            .Which.ReasonCode.Should().Be("reservation.cancel.reason-required");
+        r.Status.Should().Be(ReservationStatus.Reserved);
+    }
+}

--- a/Infrastructure/src/DependencyInjection.cs
+++ b/Infrastructure/src/DependencyInjection.cs
@@ -8,6 +8,7 @@ using BuberDinner.Domain.Menu;
 using BuberDinner.Domain.User.Entities;
 using HostEntity = BuberDinner.Domain.Host.Entities.Host;
 using DinnerEntity = BuberDinner.Domain.Dinner.Entities.Dinner;
+using ReservationEntity = BuberDinner.Domain.Reservation.Entities.Reservation;
 using BuberDinner.Infrastructure.Authentication;
 using BuberDinner.Infrastructure.Persistence.Cosmos;
 using BuberDinner.Infrastructure.Persistence.Memory;
@@ -76,6 +77,9 @@ public static class DependencyInjection
         services.AddScoped<DinnerInMemoryRepository>();
         services.AddScoped<IRepository<DinnerEntity>>(sp => sp.GetRequiredService<DinnerInMemoryRepository>());
         services.AddScoped<IDinnerRepository>(sp => sp.GetRequiredService<DinnerInMemoryRepository>());
+        services.AddScoped<ReservationInMemoryRepository>();
+        services.AddScoped<IRepository<ReservationEntity>>(sp => sp.GetRequiredService<ReservationInMemoryRepository>());
+        services.AddScoped<IReservationRepository>(sp => sp.GetRequiredService<ReservationInMemoryRepository>());
         return services;
     }
 
@@ -89,6 +93,9 @@ public static class DependencyInjection
         services.AddScoped<DinnerInMemoryRepository>();
         services.AddScoped<IRepository<DinnerEntity>>(sp => sp.GetRequiredService<DinnerInMemoryRepository>());
         services.AddScoped<IDinnerRepository>(sp => sp.GetRequiredService<DinnerInMemoryRepository>());
+        services.AddScoped<ReservationInMemoryRepository>();
+        services.AddScoped<IRepository<ReservationEntity>>(sp => sp.GetRequiredService<ReservationInMemoryRepository>());
+        services.AddScoped<IReservationRepository>(sp => sp.GetRequiredService<ReservationInMemoryRepository>());
         return services;
     }
 }

--- a/Infrastructure/src/Persistence/Memory/ReservationInMemoryRepository.cs
+++ b/Infrastructure/src/Persistence/Memory/ReservationInMemoryRepository.cs
@@ -1,0 +1,105 @@
+namespace BuberDinner.Infrastructure.Persistence.Memory;
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.Dinner.ValueObject;
+using BuberDinner.Domain.Reservation.Entities;
+using BuberDinner.Domain.User.ValueObjects;
+
+/// <summary>
+/// In-memory <see cref="IReservationRepository"/>. Same pattern as
+/// <see cref="DinnerInMemoryRepository"/> and <see cref="MenuInMemoryRepository"/>:
+/// static aggregate list + parallel ETag dictionary + reflection-based ETag write-through
+/// (framework reg-005 workaround).
+/// </summary>
+internal sealed class ReservationInMemoryRepository : IReservationRepository
+{
+    private static readonly List<Reservation> s_reservations = new();
+    private static readonly ConcurrentDictionary<string, string> s_etags = new(StringComparer.Ordinal);
+    private static readonly object s_lock = new();
+
+    public IEnumerable<Reservation> GetAll(CancellationToken cancellationToken)
+    {
+        lock (s_lock)
+            return s_reservations.ToList();
+    }
+
+    public ValueTask Add(Reservation reservation, CancellationToken cancellationToken)
+    {
+        lock (s_lock)
+        {
+            s_reservations.Add(reservation);
+            BumpETag(reservation);
+        }
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask Update(Reservation reservation, CancellationToken cancellationToken)
+    {
+        lock (s_lock)
+        {
+            int index = s_reservations.FindIndex(r => r.Id == reservation.Id);
+            if (index < 0)
+                s_reservations.Add(reservation);
+            else
+                s_reservations[index] = reservation;
+            BumpETag(reservation);
+        }
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask Delete(Reservation reservation, CancellationToken cancellationToken)
+    {
+        lock (s_lock)
+        {
+            s_reservations.RemoveAll(r => r.Id == reservation.Id);
+            s_etags.TryRemove(reservation.Id.Value.ToString(), out _);
+        }
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<Reservation?> FindById(string id, CancellationToken cancellationToken)
+    {
+        Reservation? reservation;
+        lock (s_lock)
+            reservation = s_reservations.SingleOrDefault(r => r.Id.Value.ToString() == id);
+        if (reservation is not null && s_etags.TryGetValue(id, out var etag))
+            AggregateETagWriter.SetETag(reservation, etag);
+        return ValueTask.FromResult(reservation);
+    }
+
+    public IReadOnlyList<Reservation> GetPageForDinner(DinnerId dinnerId, Trellis.PageSize pageSize, System.Guid? afterId)
+    {
+        lock (s_lock)
+        {
+            IEnumerable<Reservation> source = s_reservations
+                .Where(r => r.DinnerId == dinnerId)
+                .OrderBy(r => r.Id.Value);
+            if (afterId is { } cursorId)
+                source = source.Where(r => r.Id.Value.CompareTo(cursorId) > 0);
+            return source.Take(pageSize.Applied + 1).ToList();
+        }
+    }
+
+    public IReadOnlyList<Reservation> GetPageForGuest(UserId guestUserId, Trellis.PageSize pageSize, System.Guid? afterId)
+    {
+        lock (s_lock)
+        {
+            IEnumerable<Reservation> source = s_reservations
+                .Where(r => r.GuestUserId == guestUserId)
+                .OrderBy(r => r.Id.Value);
+            if (afterId is { } cursorId)
+                source = source.Where(r => r.Id.Value.CompareTo(cursorId) > 0);
+            return source.Take(pageSize.Applied + 1).ToList();
+        }
+    }
+
+    private static void BumpETag(Reservation reservation)
+    {
+        var newETag = Guid.NewGuid().ToString("N");
+        s_etags[reservation.Id.Value.ToString()] = newETag;
+        AggregateETagWriter.SetETag(reservation, newETag);
+    }
+}

--- a/Infrastructure/src/Persistence/Memory/ReservationInMemoryRepository.cs
+++ b/Infrastructure/src/Persistence/Memory/ReservationInMemoryRepository.cs
@@ -8,12 +8,6 @@ using BuberDinner.Domain.Dinner.ValueObject;
 using BuberDinner.Domain.Reservation.Entities;
 using BuberDinner.Domain.User.ValueObjects;
 
-/// <summary>
-/// In-memory <see cref="IReservationRepository"/>. Same pattern as
-/// <see cref="DinnerInMemoryRepository"/> and <see cref="MenuInMemoryRepository"/>:
-/// static aggregate list + parallel ETag dictionary + reflection-based ETag write-through
-/// (framework reg-005 workaround).
-/// </summary>
 internal sealed class ReservationInMemoryRepository : IReservationRepository
 {
     private static readonly List<Reservation> s_reservations = new();

--- a/Requests/Dinners/ListReservationsForDinner.http
+++ b/Requests/Dinners/ListReservationsForDinner.http
@@ -1,0 +1,19 @@
+### Host view: paginated list of every reservation against one of their dinners.
+### Gated by Host ownership via `IAuthorizeResource<Host>` — only the route host's owner
+### can read. Same envelope shape as Reservations/ListMyReservations.http.
+
+@token = yourtoken
+@hostId = 019E9690-0ECA-7523-8AD5-E75B71E572DE
+@dinnerId = 019E9690-0FDC-7AA6-9807-7F0A56F08C42
+
+GET {{host}}/hosts/{{hostId}}/dinners/{{dinnerId}}/reservations?api-version=2022-10-01&limit=10
+Authorization: Bearer {{token}}
+
+### Expected response (happy path):
+### HTTP/1.1 200 OK
+### { "items":[ <ReservationResponse>, ... ],
+###   "next":  { ... } or null,
+###   "previous": null,
+###   "requestedLimit": 10, "appliedLimit": 10, "deliveredCount": <=10, "wasCapped": false }
+###
+### As a different host → 403 Forbidden with code `reservations.host.owner`.

--- a/Requests/Reservations/CancelReservation.http
+++ b/Requests/Reservations/CancelReservation.http
@@ -1,0 +1,21 @@
+### Cancel an active reservation. Only the owning guest can cancel — other callers
+### (including the dinner's host) get 404 (NotFound-leak-shield).
+
+@token = yourtoken
+@reservationId = 019E9690-10F4-7584-8AB7-5AF569F6983A
+
+POST {{host}}/reservations/{{reservationId}}/cancel?api-version=2022-10-01
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "reason": "Schedule conflict"
+}
+
+### Expected response (happy path):
+### HTTP/1.1 200 OK
+### ETag: "<new>"
+### { ..., "status":"Cancelled", "cancelledAt":"...", "cancellationReason":"Schedule conflict" }
+###
+### Cancel-again returns 422 with code `state.machine.invalid.transition`
+### (Cookbook Recipe 9 — terminal-state guard).

--- a/Requests/Reservations/CreateReservation-FailureModes.http
+++ b/Requests/Reservations/CreateReservation-FailureModes.http
@@ -1,0 +1,63 @@
+### Three failure modes for POST /reservations:
+###
+###   1. Missing Idempotency-Key       → 400 `idempotency.key_required` (middleware-level)
+###   2. Same key + DIFFERENT body     → 422 fingerprint mismatch (no replay possible)
+###   3. POST against missing DinnerId → 404 (Cookbook Recipe 22 — fail-loud on missing related)
+
+@token = yourtoken
+@dinnerId = 019E9690-0FDC-7AA6-9807-7F0A56F08C42
+@phantomDinner = 00000000-1111-2222-3333-444444444444
+@key = 12345678-1234-1234-1234-1234567890ab
+
+### 1. Missing Idempotency-Key → 400.
+POST {{host}}/reservations?api-version=2022-10-01
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "dinnerId": "{{dinnerId}}",
+    "guestCount": 1
+}
+
+### Expected:
+### HTTP/1.1 400 Bad Request
+### { "status":400, "detail":"This endpoint requires the Idempotency-Key header.",
+###   "code":"idempotency.key_required" }
+
+
+### 2. Same key as a prior successful call but a DIFFERENT body → 422 (fingerprint mismatch).
+###    Assumes you already ran CreateReservation.http with guestCount=2 and the same key.
+###    The framework rejects so the caller knows the key was reused with mutated input.
+POST {{host}}/reservations?api-version=2022-10-01
+Authorization: Bearer {{token}}
+Content-Type: application/json
+Idempotency-Key: {{key}}
+
+{
+    "dinnerId": "{{dinnerId}}",
+    "guestCount": 5
+}
+
+### Expected:
+### HTTP/1.1 422 Unprocessable Entity
+### (Problem Details body indicating fingerprint mismatch)
+
+
+### 3. POST against a non-existent dinner → 404 (Recipe 22 fail-loud).
+###    Without this check, the handler would silently create an orphan reservation row
+###    pointing at a non-existent dinner — the post-condition "every reservation references
+###    a real dinner" would be broken with no signal to the caller.
+POST {{host}}/reservations?api-version=2022-10-01
+Authorization: Bearer {{token}}
+Content-Type: application/json
+Idempotency-Key: 99999999-9999-9999-9999-999999999999
+
+{
+    "dinnerId": "{{phantomDinner}}",
+    "guestCount": 1
+}
+
+### Expected:
+### HTTP/1.1 404 Not Found
+### { "status":404, "code":"not-found",
+###   "instance":"/dinners/00000000-1111-2222-3333-444444444444" }

--- a/Requests/Reservations/CreateReservation.http
+++ b/Requests/Reservations/CreateReservation.http
@@ -1,0 +1,35 @@
+### Reserve a seat at an upcoming dinner. The endpoint is opted into the IETF
+### Idempotency-Key middleware (Cookbook Recipe 29): a retry with the same key + body
+### returns the cached 201 byte-for-byte (no double-booking). Same key + DIFFERENT body
+### → 422 fingerprint mismatch. Missing key → 400 `idempotency.key_required`.
+
+@token = yourtoken
+@dinnerId = 019E9690-0FDC-7AA6-9807-7F0A56F08C42
+@key = 12345678-1234-1234-1234-1234567890ab
+
+POST {{host}}/reservations?api-version=2022-10-01
+Authorization: Bearer {{token}}
+Content-Type: application/json
+Idempotency-Key: {{key}}
+
+{
+    "dinnerId": "{{dinnerId}}",
+    "guestCount": 2
+}
+
+### Expected response (first call):
+### HTTP/1.1 201 Created
+### ETag: "..."
+### Location: /reservations/{reservationId}
+### { "id":"...", "dinnerId":"...", "guestUserId":"...", "guestCount":2,
+###   "status":"Reserved", "reservedAt":"...", "cancelledAt":null, "cancellationReason":null }
+###
+### Expected response (replay — same key+body):
+### HTTP/1.1 201 Created
+### ETag: "..."  (identical to first)
+### Location: /reservations/{same-id}
+### Idempotent-Replayed: true   ← framework's marker that this is a cached response
+### { same body as first call, byte for byte }
+###
+### Side effect (visible in server logs):
+###   info: LogReservationCreatedHandler[0] Reservation X created by guest Y for dinner Z (2 seats) at ...

--- a/Requests/Reservations/ListMyReservations.http
+++ b/Requests/Reservations/ListMyReservations.http
@@ -1,0 +1,14 @@
+### Paginated list of the calling guest's own reservations. Same cursor pagination shape
+### as PR 3's ListDinners / ListMenus.
+
+@token = yourtoken
+
+GET {{host}}/reservations/mine?api-version=2022-10-01&limit=10
+Authorization: Bearer {{token}}
+
+### Expected response:
+### HTTP/1.1 200 OK
+### { "items":[ <ReservationResponse>, ... ],
+###   "next":  { "cursor": "...", "href": "https://.../reservations/mine?cursor=...&limit=10&api-version=..." } or null,
+###   "previous": null,
+###   "requestedLimit": 10, "appliedLimit": 10, "deliveredCount": <=10, "wasCapped": false }


### PR DESCRIPTION
# PR 4 — Reservations + IETF Idempotency-Key + multi-aggregate fail-loud

> *Fourth in the 5-PR showcase arc. Adds the Reservation aggregate, opts the create
> endpoint into the IETF `Idempotency-Key` middleware (Cookbook Recipe 29) so network
> retries can't double-book, and demonstrates the Recipe 22 fail-loud-on-missing-related
> pattern via the Dinner ↔ Reservation relationship.*

## TL;DR

| What | Where | Cookbook |
|---|---|---|
| `Reservation` aggregate with one-transition `LazyStateMachine<,>` | `Domain/src/Reservation/Entities/Reservation.cs` | Recipe 9 |
| `ReservationCreated` / `ReservationCancelled` events (`OccurredAt` only) | `Domain/src/Reservation/Events/` | Recipe 17 |
| `POST /reservations` opted-in to IETF Idempotency-Key via `[Idempotent]` | `ReservationsController` | Recipe 29 |
| Recipe 22 fail-loud: handler loads parent Dinner first, 404 if missing | `CreateReservationCommandHandler` | Recipe 22 |
| `POST /reservations/{id}/cancel` with NotFound-leak-shield (cross-guest → 404) | `CancelReservationCommandHandler` | — |
| `GET /reservations/{id}` (owner-only) + `GET /reservations/mine` (paginated, guest view) | `ReservationsController` | Recipe 3 |
| `GET /hosts/{hostId}/dinners/{dinnerId}/reservations` (paginated, host view, `IAuthorizeResource<Host>`) | `ListReservationsForDinnerQuery` | Recipes 3 + 7 |
| `AddTrellisIdempotency(...)` + `AddInMemoryIdempotencyStore()` + `app.UseTrellisIdempotency()` | DI + `Program.cs` | Recipe 29 |

## The idempotency contract (wire-verified)

```http
# 1. First POST with an Idempotency-Key → 201 + Location + ETag.
POST /reservations
Idempotency-Key: 12345678-1234-1234-1234-1234567890ab
{ "dinnerId": "...", "guestCount": 2 }

HTTP/1.1 201 Created
ETag: "0c3c7a80336049ae992bba0456801b05"
Location: /reservations/019e9690-10f4-7584-8ab7-5af569f6983a
{ "id": "019e9690-10f4-7584-8ab7-5af569f6983a", "status": "Reserved", ... }

# 2. Retry — same key, same body → 201 + IDENTICAL body + Idempotent-Replayed: true.
POST /reservations
Idempotency-Key: 12345678-1234-1234-1234-1234567890ab
{ "dinnerId": "...", "guestCount": 2 }

HTTP/1.1 201 Created
ETag: "0c3c7a80336049ae992bba0456801b05"   ← same as #1
Location: /reservations/019e9690-10f4-7584-8ab7-5af569f6983a   ← same id
Idempotent-Replayed: true                                       ← framework's marker

# 3. Same key, DIFFERENT body → 422 fingerprint mismatch.
POST /reservations
Idempotency-Key: 12345678-1234-1234-1234-1234567890ab
{ "dinnerId": "...", "guestCount": 5 }   ← mutated
HTTP/1.1 422 Unprocessable Entity

# 4. Missing Idempotency-Key on an [Idempotent] endpoint → 400.
POST /reservations
{ "dinnerId": "...", "guestCount": 1 }
HTTP/1.1 400 Bad Request
{ "status":400, "code":"idempotency.key_required",
  "detail":"This endpoint requires the Idempotency-Key header." }
```

The Replay test additionally inspects `GET /reservations/mine` and asserts exactly ONE
row exists — proves no double-booking happened, not just that the second response
matched the first.

**Per-actor scope is critical:** the middleware sits AFTER `UseAuthentication`/`UseAuthorization`
in `Program.cs` so the default `DefaultIdempotencyScopeResolver` sees the authenticated
Actor and partitions the store by it. Mounting before auth would let every authenticated
request fall back to the shared `anonymous` scope, where different users could collide
on the same Idempotency-Key.

## Recipe 22 fail-loud in one handler

```csharp
public async ValueTask<Result<Reservation>> Handle(
    CreateReservationCommand request, CancellationToken cancellationToken)
{
    // Load the related aggregate FIRST. If missing, fail-loud with NotFound so
    // the post-condition "every reservation references a real dinner" holds.
    var dinner = await _dinnerRepository.FindById(request.DinnerId.Value.ToString(), cancellationToken);
    if (dinner is null)
        return Result.Fail<Reservation>(new Error.NotFound(ResourceRef.For<Dinner>(request.DinnerId)));

    // State precondition: only Upcoming dinners take reservations.
    if (dinner.Status != DinnerStatus.Upcoming)
        return Result.Fail<Reservation>(
            Error.InvalidInput.ForRule("reservation.dinner-not-upcoming",
                $"Cannot reserve against a dinner whose status is {dinner.Status.Value}."));

    var reservationResult = Reservation.TryCreate(
        request.DinnerId, request.GuestUserId, request.GuestCount, _clock);
    if (reservationResult.IsFailure) return reservationResult;

    await _reservationRepository.Add(reservationResult.GetValueOrThrow("r"), cancellationToken);
    return reservationResult;
}
```

Anti-pattern: silently insert the reservation row and let it dangle. Fail-loud surfaces
the missing aggregate at the API boundary as 404 with the Dinner's `ResourceRef`.

## Authorization shape

| Endpoint | Auth |
|---|---|
| `POST /reservations` | Authenticated; guest id from JWT `sub` |
| `GET /reservations/{id}` | Authenticated; 404 if `reservation.GuestUserId != caller` (leak-shielded) |
| `POST /reservations/{id}/cancel` | Same NotFound-leak-shield |
| `GET /reservations/mine` | Authenticated; scoped to caller's UserId |
| `GET /hosts/{hostId}/dinners/{dinnerId}/reservations` | `IAuthorizeResource<Host>`; 403 with `code: "reservations.host.owner"` |

## Commit walkthrough (5 commits)

| # | sha | Scope |
|---|---|---|
| 1 | `8166512` | `feat(domain)`: Reservation aggregate + 2 events + 6 domain tests |
| 2 | `d5160fe` | `feat(infra+app)`: Reservation repo + 4 commands/queries + 2 log handlers |
| 3 | `47259ea` | `feat(api)`: ReservationsController + `[Idempotent]` middleware wiring |
| 4 | `ae27dc5` | `test(api)`: 9 integration tests covering all 9 wire scenarios |
| 5 | `b1e902b` | `docs`: PR4_RESERVATIONS_AND_IDEMPOTENCY.md + Aggregates.Reservation.md + 5 `.http` files |

## Build, test, wire-verify

- **0 warnings / 0 errors**
- **Domain 37/37** (+6 new Reservation tests)
- **Application 1/1** (unchanged)
- **Api 60/60** (+9 new Reservation integration tests)
- Infrastructure 0/2 (live-Cosmos baseline, pre-existing)

## What's NOT in this PR (deferred)

- **`MaxGuests` / capacity tracking on Dinner** — would have required updating
  `Dinner.TryCreate` signature + breaking PR 2/3 tests. Recipe 22 is still showcased via
  the existence check; capacity tracking is its own future PR.
- **`IAuthorizeResource<Reservation>`** — guest-owns-reservation check is in the handler
  for now. Mechanical follow-on to wire a `SharedResourceLoaderById<Reservation, ReservationId>`.
- **EF-backed `IIdempotencyStore`** — production-grade, multi-instance. PR 4 ships the
  in-memory dev/test store only.

## Roadmap

- **PR 5** (final): Reviews aggregate + `AddTrellisFluentValidation` at command boundary +
  `Trellis.Testing` matchers + `Trellis.ServiceDefaults` composition root
