### PR TITLE
feat: Reviews aggregate + FluentValidation + Trellis.Testing + ServiceDefaults

### DIFF
--- a/.github/trellis-api-mediator-fluentvalidation.md
+++ b/.github/trellis-api-mediator-fluentvalidation.md
@@ -1,0 +1,132 @@
+﻿---
+package: Trellis.Mediator.FluentValidation
+namespaces: [Trellis.Mediator.FluentValidation]
+types: [FluentValidationServiceCollectionExtensions, FluentValidationMessageValidatorAdapter<TMessage>]
+version: v3
+last_verified: 2026-06-04
+audience: [llm]
+---
+# Trellis.Mediator.FluentValidation — API Reference
+
+## Header
+
+- **Package:** `Trellis.Mediator.FluentValidation`
+- **Namespace:** `Trellis.Mediator.FluentValidation`
+- **Purpose:** Plugs FluentValidation validators into the Trellis Mediator validation stage. Provides one DI extension class and one open-generic `IMessageValidator<TMessage>` adapter; no additional pipeline behavior is added.
+- **Depends on:** `Trellis.Mediator` (for `IMessageValidator<TMessage>` and the `IMessage` constraint) and `Trellis.FluentValidation` (for `JsonPointerNormalizer` and the standalone `Result<T>` helpers).
+
+> **Why this is a separate package.** `Trellis.FluentValidation` carries the Mediator-agnostic helpers — the `ValidationResult → Result<T>` extensions and the `JsonPointerNormalizer`. The Mediator-specific bits (the adapter and its DI extension) live here so an application that only wants the standalone helpers does not pull in `Trellis.Mediator`. The adapter's behavior, idempotency guarantees, and AOT/trim contract are unchanged from prior versions; only the package and namespace moved.
+
+See also: [trellis-api-cookbook.md](trellis-api-cookbook.md#recipe-2--command--handler--fluentvalidation--ef-persistence) — recipes using this package.
+
+## Use this file when
+
+- You want FluentValidation validators to run inside the Trellis Mediator validation behavior.
+- You need to register validators by assembly scanning (non-AOT) or explicitly (AOT/trim-safe).
+- You need the wire-up rules for combining FluentValidation failures with `IValidate.Validate()` failures into a single `Error.InvalidInput`.
+
+## Patterns Index
+
+| Goal | Canonical API / pattern | See |
+|---|---|---|
+| Add the FluentValidation adapter without scanning | `services.AddTrellisFluentValidation()` plus explicit `IValidator<T>` registrations | [`FluentValidationServiceCollectionExtensions`](#fluentvalidationservicecollectionextensions) |
+| Add the adapter and scan assemblies | `services.AddTrellisFluentValidation(typeof(SomeType).Assembly)` | [`FluentValidationServiceCollectionExtensions`](#fluentvalidationservicecollectionextensions) |
+| Keep AOT/trim safety | Use the parameterless adapter overload and register validators explicitly | [`FluentValidationServiceCollectionExtensions`](#fluentvalidationservicecollectionextensions) |
+| Understand nested/indexed field paths | FluentValidation names are normalized to RFC 6901 JSON Pointers via [`JsonPointerNormalizer`](trellis-api-fluentvalidation.md#jsonpointernormalizer) | [Pointer normalization](#pointer-normalization-rfc-6901) |
+
+## Common traps
+
+- `AddTrellisFluentValidation()` does not add a second mediator pipeline behavior; it registers `IMessageValidator<TMessage>` so the existing `ValidationBehavior` can aggregate failures.
+- The assembly-scanning overload is intentionally not AOT/trim-safe. Use explicit registrations for AOT-sensitive apps.
+- Keep primitive-to-value-object parsing at the transport seam; validators should normally validate already-shaped command/value-object inputs.
+- The diagnostic log category emitted by the scanning overload is still `"Trellis.FluentValidation"` so existing logging filters continue to work after the package split.
+
+## Types
+
+### `FluentValidationServiceCollectionExtensions`
+
+**Declaration**
+
+```csharp
+public static class FluentValidationServiceCollectionExtensions
+```
+
+**Methods**
+
+| Signature | Returns | Description |
+| --- | --- | --- |
+| `public static IServiceCollection AddTrellisFluentValidation(this IServiceCollection services)` | `IServiceCollection` | Registers `FluentValidationMessageValidatorAdapter<TMessage>` as the open-generic `IMessageValidator<TMessage>` implementation. Every `IValidator<T>` registered for the message in DI then runs inside the existing `ValidationBehavior<TMessage,TResponse>` and contributes its failures to an aggregated `Error.InvalidInput`. **AOT/trim-safe**; uses open-generic DI registration with no reflection. Idempotent — repeated calls do not duplicate the adapter. Throws `ArgumentNullException` when `services` is `null`. Validators must be registered explicitly (e.g., `services.AddScoped<IValidator<CreateOrderCommand>, CreateOrderCommandValidator>()`). |
+| `public static IServiceCollection AddTrellisFluentValidation(this IServiceCollection services, params Assembly[] assemblies)` | `IServiceCollection` | Calls the parameterless overload, then scans the supplied assemblies for concrete `IValidator<T>` implementations and registers each as a scoped service. **Not AOT or trim-compatible** — annotated `[RequiresUnreferencedCode]` and `[RequiresDynamicCode]`. Skips abstract/interface/open-generic types. Deduplicates so repeated calls (or overlapping assemblies) do not register the same validator twice. Throws `ArgumentNullException` for null `services`/`assemblies`, and `ArgumentException` when `assemblies` is empty or contains a `null` element. Tolerates `ReflectionTypeLoadException` by using only loadable types and emits a single Warning per affected assembly via `ILoggerFactory` (when one is registered). The diagnostic log category remains `"Trellis.FluentValidation"` for log-filter compatibility. |
+
+### `FluentValidationMessageValidatorAdapter<TMessage>`
+
+**Declaration**
+
+```csharp
+public sealed class FluentValidationMessageValidatorAdapter<TMessage>(
+    IEnumerable<IValidator<TMessage>> validators)
+    : IMessageValidator<TMessage>
+    where TMessage : Mediator.IMessage
+```
+
+**Methods**
+
+| Signature | Returns | Description |
+| --- | --- | --- |
+| `public ValueTask<IResult> ValidateAsync(TMessage message, CancellationToken cancellationToken)` | `ValueTask<IResult>` | Runs every injected `IValidator<TMessage>` against `message`. Returns `Result.Ok()` when all validators pass (or none are registered — the empty injected sequence allocates no violations). Otherwise aggregates every `ValidationFailure` into a single `new Error.InvalidInput(EquatableArray.Create(violations))`, where `violations` is the collected `FieldViolation` set. Each FluentValidation failure becomes a `FieldViolation(new InputPointer(pointerPath), reasonCode) { Detail = failure.ErrorMessage }`. `pointerPath` is derived by `JsonPointerNormalizer.ToJsonPointer` from the FV property name; `reasonCode` defaults to `"validation.error"` when `failure.ErrorCode` is null/whitespace. Root-level failures (whitespace `PropertyName`) use `typeof(TMessage).Name`. |
+
+### Pointer normalization (RFC 6901)
+
+FluentValidation property names are converted to JSON Pointers via [`JsonPointerNormalizer`](trellis-api-fluentvalidation.md#jsonpointernormalizer) so they round-trip through `InputPointer`:
+
+| FluentValidation `PropertyName` | Resulting `InputPointer.RawValue` |
+| --- | --- |
+| `Email` | `/Email` |
+| `Address.PostCode` | `/Address/PostCode` |
+| `Items[0].Sku` | `/Items/0/Sku` |
+
+Dotted FluentValidation paths split into separate JSON-pointer segments; bracketed indexers become numeric segments. Other producers (e.g., the ASP integration) build `InputPointer` values directly via `InputPointer.ForProperty(...)`, which does **not** split on `.`, so the normalizer is FluentValidation-specific.
+
+## Behavioral notes
+
+- FluentValidation does **not** add an additional pipeline behavior. It plugs into the existing `ValidationBehavior<TMessage,TResponse>` via the open-generic `IMessageValidator<TMessage>` extension point.
+- The adapter is registered scoped, matching the typical scoped lifetime of FluentValidation validators.
+- When no `IValidator<TMessage>` is registered for a message type, `IEnumerable<IValidator<TMessage>>` is empty, the adapter returns `Result.Ok()`, and no allocations are performed.
+- All validators are awaited sequentially; failures from every validator are aggregated into a single `Error.InvalidInput` rather than short-circuiting on the first failure.
+- The adapter forwards the ambient `CancellationToken` to `validator.ValidateAsync`.
+- `AddTrellisFluentValidation()` is **idempotent** — calling it multiple times (directly, or via the scanning overload) only registers the open-generic adapter once.
+- The assembly-scan overload deduplicates `(serviceType, implementationType)` pairs against existing registrations, so calling it twice with overlapping assemblies will not register a validator more than once.
+
+## Code examples
+
+### Wire FluentValidation into the Mediator pipeline (AOT-safe)
+
+```csharp
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis.Mediator;
+using Trellis.Mediator.FluentValidation;
+
+services.AddTrellisBehaviors();
+services.AddTrellisFluentValidation();
+
+// Register validators explicitly so the call site is AOT/trim-friendly.
+services.AddScoped<IValidator<CreateOrderCommand>, CreateOrderCommandValidator>();
+services.AddScoped<IValidator<UpdateOrderCommand>, UpdateOrderCommandValidator>();
+```
+
+### Wire FluentValidation with assembly scanning (not AOT-compatible)
+
+```csharp
+using Trellis.Mediator.FluentValidation;
+
+services.AddTrellisBehaviors();
+services.AddTrellisFluentValidation(typeof(CreateOrderCommandValidator).Assembly);
+```
+
+## Cross-references
+
+- [trellis-api-fluentvalidation.md](trellis-api-fluentvalidation.md#header) — the standalone `ValidationResult → Result<T>` helpers and `JsonPointerNormalizer` that this package builds on.
+- [trellis-api-mediator.md](trellis-api-mediator.md#validationbehaviortmessage-tresponse) — the pipeline stage this adapter participates in.
+- [trellis-api-core.md](trellis-api-core.md#public-abstract-record-error) — `Error.InvalidInput` shape.
+- [trellis-api-asp.md](trellis-api-asp.md#domain--http-boundary-mapping) — how `Error.InvalidInput` lands on the wire.

--- a/.github/trellis-api-servicedefaults.md
+++ b/.github/trellis-api-servicedefaults.md
@@ -1,0 +1,179 @@
+﻿---
+package: Trellis.ServiceDefaults
+namespaces: [Trellis.ServiceDefaults]
+types: [TrellisServiceCollectionExtensions, TrellisServiceBuilder]
+version: v3
+last_verified: 2026-06-03
+audience: [llm]
+---
+# Trellis.ServiceDefaults API Reference
+
+**Package:** `Trellis.ServiceDefaults`  
+**Namespace:** `Trellis.ServiceDefaults`  
+**Purpose:** Opinionated composition builder for API/composition-root projects that want Trellis integration modules applied in the canonical order.
+
+See also: [trellis-api-cookbook.md](trellis-api-cookbook.md#recipe-12--di-wiring-playbook-addtrellis-composition-builder) — composition-root recipe.
+
+## Use this file when
+
+- You are wiring a composition root and want Trellis modules applied in the canonical order.
+- You want one fluent builder for ASP, Mediator, FluentValidation, resource authorization, actor provider, and EF unit-of-work registration.
+- You need to know what `AddTrellis(...)` deliberately does not register.
+
+## Patterns Index
+
+| Goal | Canonical API / pattern | See |
+|---|---|---|
+| Enable ASP Result-to-HTTP mapping | `services.AddTrellis(o => o.UseAsp())` | [`TrellisServiceBuilder`](#trellisservicebuilder), [ASP](trellis-api-asp.md#domain--http-boundary-mapping) |
+| Enable scalar-value JSON / model-binding validation | `services.AddTrellis(o => o.UseScalarValueValidation())` (compose with `.UseAsp()` for the controller-host default) | [`TrellisServiceBuilder`](#trellisservicebuilder), [ASP](trellis-api-asp.md#namespace-trellisaspvalidation) |
+| Enable Trellis ProblemDetails customization | `.UseProblemDetails()` | [`TrellisServiceBuilder`](#trellisservicebuilder), [ASP `AddTrellisProblemDetails`](trellis-api-asp.md#servicecollectionextensions) |
+| Enable the IETF `Idempotency-Key` middleware for opted-in `POST` / `PATCH` endpoints | `.UseIdempotency(opt => ...)` plus `services.AddInMemoryIdempotencyStore()` (or an EF-backed store) and `app.UseTrellisIdempotency()` | [`TrellisServiceBuilder`](#trellisservicebuilder), [ASP `Trellis.Asp.Idempotency`](trellis-api-asp.md#namespace-trellisaspidempotency), Cookbook [Recipe 29](trellis-api-cookbook.md#recipe-29--ietf-idempotency-key-middleware-on-post--patch-with-usetrellisidempotency) |
+| Add standard mediator behaviors | `.UseMediator()` | [`TrellisServiceBuilder`](#trellisservicebuilder), [Mediator](trellis-api-mediator.md#trellismediatorservicecollectionextensions) |
+| Add FluentValidation adapter/scanning | `.UseFluentValidation(typeof(Program).Assembly)` or `.UseFluentValidation()` | [`TrellisServiceBuilder`](#trellisservicebuilder), [FluentValidation](trellis-api-mediator-fluentvalidation.md#fluentvalidationservicecollectionextensions) |
+| Add resource authorization | `.UseResourceAuthorization(...)` | [`TrellisServiceBuilder`](#trellisservicebuilder), [Mediator resource authorization](trellis-api-mediator.md#resourceauthorizationbehaviortmessage-tresource-tresponse) |
+| Register an actor provider | `.UseClaimsActorProvider()`, `.UseNestedJsonPathClaimsActorProvider()`, `.UseEntraActorProvider()`, or `.UseDevelopmentActorProvider()` | [`TrellisServiceBuilder`](#trellisservicebuilder), [ASP actor providers](trellis-api-asp.md#namespace-trellisaspauthorization) |
+| Add EF unit-of-work behavior | `.UseEntityFrameworkUnitOfWork<TContext>()` | [`TrellisServiceBuilder`](#trellisservicebuilder), [Mediator UoW](trellis-api-mediator.md#cross-package-preflight-for-pipeline-changes) |
+| Dispatch domain events from successful commands | `.UseDomainEvents(typeof(MyHandler).Assembly)` or `.UseDomainEvents()` | [`TrellisServiceBuilder`](#trellisservicebuilder), [Mediator domain events](trellis-api-mediator.md#domaineventdispatchbehavior) |
+| Auto-dispatch domain events from every tracked aggregate (outcome-DTO commands) | `.UseTrackedAggregateDomainEvents(typeof(MyHandler).Assembly)` or `.UseTrackedAggregateDomainEvents()` | [`TrellisServiceBuilder`](#trellisservicebuilder), [Mediator tracked dispatch](trellis-api-mediator.md#trackedaggregatedomaineventdispatchbehavior) |
+
+## Common traps
+
+- `AddTrellis(...)` does not register `DbContext`, Mediator handlers, or route constraints — those are always application-owned. Validators (`IValidator<T>`), resource loaders (`IResourceLoader<TMessage, TResource>`), and domain event handlers (`IDomainEventHandler<TEvent>`) are registered ONLY when you opt into assembly scanning via the params-`Assembly[]` overloads (`UseFluentValidation(asm)`, `UseResourceAuthorization(asm)`, `UseDomainEvents(asm)`); the parameterless overloads register only the adapter / pipeline behavior and leave per-type registrations to you.
+- `UseEntityFrameworkUnitOfWork<TContext>()` is applied last so transaction commit remains innermost in the mediator pipeline.
+- Calling `UseEntityFrameworkUnitOfWork<TContext>()` more than once (with the same or a different `TContext`) throws `InvalidOperationException`. The Trellis pipeline supports exactly one transactional `IUnitOfWork` per composition; chaining two calls (e.g. for a read/write context split) is always misconfiguration. Use a separate composition root or a single multi-tenant `DbContext` instead.
+- If you only need one module, direct package-specific registration remains valid; the builder is for composition-root clarity.
+
+## AOT compatibility
+
+`Trellis.ServiceDefaults` is now **AOT- and trim-compatible** (`<IsAotCompatible>true</IsAotCompatible>`, `<IsTrimmable>true</IsTrimmable>`, `<EnableAotAnalyzer>true</EnableAotAnalyzer>`, `<EnableTrimAnalyzer>true</EnableTrimAnalyzer>`). The compatibility surface is split across two overload shapes per assembly-scanning slot:
+
+| Slot | AOT-safe overload | Scanning overload (`[RequiresUnreferencedCode]` + `[RequiresDynamicCode]`) |
+| --- | --- | --- |
+| FluentValidation | `o.UseFluentValidation()` (adapter only) plus `o.UseFluentValidation<TValidator, TMessage>()` per validator | `o.UseFluentValidation(asm)` |
+| Resource authorization | `o.UseResourceAuthorization()` (pipeline only) plus `o.UseResourceAuthorization<TMessage, TResource, TResponse>()` per command | `o.UseResourceAuthorization(asm)` |
+| Domain events (response-shape) | `o.UseDomainEvents()` (publisher + behavior only) plus `o.UseDomainEvents<TEvent, THandler>()` per handler | `o.UseDomainEvents(asm)` |
+| Domain events (tracked-aggregate) | `o.UseTrackedAggregateDomainEvents()` (publisher + behavior only) plus `o.UseTrackedAggregateDomainEvents<TEvent, THandler>()` per handler | `o.UseTrackedAggregateDomainEvents(asm)` |
+
+The AOT-safe overloads use only open-generic DI registrations and explicit closed-type method calls — no reflection over assemblies. The scanning overloads remain available for fast iteration in non-AOT consumers and surface the IL2026 / IL3050 warnings at the consumer's call site so the choice between AOT and convenience is explicit, never silent.
+
+Direct per-package registrations (`services.AddTrellisFluentValidation()` from `Trellis.Mediator.FluentValidation`, `services.AddResourceAuthorization<TMessage, TResource, TResponse>()`, `services.AddDomainEventHandler<TEvent, THandler>()`) remain valid as an escape hatch — call them outside the builder when you need to register a type the builder does not yet model.
+
+## Types
+
+### `TrellisServiceCollectionExtensions`
+
+```csharp
+public static class TrellisServiceCollectionExtensions
+```
+
+| Signature | Returns | Description |
+| --- | --- | --- |
+| `public static IServiceCollection AddTrellis(this IServiceCollection services, Action<TrellisServiceBuilder> configure)` | `IServiceCollection` | Creates a `TrellisServiceBuilder`, lets the caller select modules, then applies the selected modules in canonical order. Does not register `DbContext` or Mediator handlers. |
+
+### `TrellisServiceBuilder`
+
+```csharp
+public sealed class TrellisServiceBuilder
+```
+
+| Signature | Returns | Description |
+| --- | --- | --- |
+| `public TrellisServiceBuilder UseAsp(Action<TrellisAspOptions>? configure = null)` | `TrellisServiceBuilder` | Registers `Trellis.Asp` integration via `AddTrellisAsp(...)` (error-to-status mapping + `ResourceCollectionNameRegistry`). **Does NOT register scalar-value validation** — compose with `UseScalarValueValidation()` when the host binds value-object DTOs from JSON / route / query. Repeated calls compose the configure delegates rather than overwriting. |
+| `public TrellisServiceBuilder UseScalarValueValidation()` | `TrellisServiceBuilder` | Registers scalar-value validation via `AddScalarValueValidation()`: configures both MVC and Minimal API JSON pipelines (model binders, JSON converters, `SuppressModelStateInvalidFilter` toggle) so `IScalarValue<TSelf, TPrimitive>` / `Maybe<T>` validation surfaces as RFC 9457 ProblemDetails. Mutates global `MvcOptions` / `JsonOptions`. Independent of `UseAsp()`. **Does NOT register the Minimal API endpoint filter or middleware** — Minimal API hosts must additionally call `app.UseScalarValueValidation()` (middleware) and chain `.WithScalarValueValidation()` per endpoint. Idempotent. |
+| `public TrellisServiceBuilder UseProblemDetails()` | `TrellisServiceBuilder` | Registers Trellis ProblemDetails customization (`traceId` on every error, `405` `Allow` header projected as `extensions.allow`, `500` detail rewrite) via `AddTrellisProblemDetails()`. Independent of `UseAsp()` — does not pull in Trellis MVC/result-mapping infrastructure. Idempotent across direct + builder composition: a consumer that calls both `services.AddTrellisProblemDetails()` directly and `options.UseProblemDetails()` ends up with exactly one Trellis post-configure layer. |
+| `public TrellisServiceBuilder UseIdempotency(Action<IdempotencyOptions>? configure = null)` | `TrellisServiceBuilder` | Registers `AddTrellisIdempotency(configure)`: startup-validated `IdempotencyOptions`, the default `IIdempotencyScopeResolver` (per-actor, falling back to anonymous), and an internal marker used by `app.UseTrellisIdempotency()` for startup validation. **Does not register a store** — composition is explicit; pair with `services.AddInMemoryIdempotencyStore()` (dev / tests) or an EF-backed store (production). Mount the middleware with `app.UseTrellisIdempotency()` in the request pipeline. Independent of `UseAsp()`. Repeated calls compose the configure delegates rather than overwriting, mirroring `UseAsp` / `UseMediator`. |
+| `public TrellisServiceBuilder UseMediator(Action<TrellisMediatorTelemetryOptions>? configureTelemetry = null)` | `TrellisServiceBuilder` | Registers Trellis Mediator behaviors via `AddTrellisBehaviors(...)`. Repeated calls compose the configure delegates rather than overwriting. |
+| `public TrellisServiceBuilder UseFluentValidation()` | `TrellisServiceBuilder` | **AOT-safe.** Registers the FluentValidation adapter only; pair with `UseFluentValidation<TValidator, TMessage>()` or explicit per-validator DI registrations. Implies `UseMediator()`. |
+| `public TrellisServiceBuilder UseFluentValidation<TValidator, TMessage>() where TValidator : class, IValidator<TMessage>` | `TrellisServiceBuilder` | **AOT-safe.** Registers `TValidator` as the `IValidator<TMessage>` and wires the FluentValidation adapter. Implies `UseMediator()`. |
+| `[RequiresUnreferencedCode] [RequiresDynamicCode] public TrellisServiceBuilder UseFluentValidation(params Assembly[] assemblies)` | `TrellisServiceBuilder` | Registers the FluentValidation adapter and scans the supplied assemblies for `IValidator<T>` implementations (non-AOT). Implies `UseMediator()`. |
+| `public TrellisServiceBuilder UseResourceAuthorization()` | `TrellisServiceBuilder` | **AOT-safe.** Enables the resource-authorization pipeline without scanning. Implies `UseMediator()`. |
+| `public TrellisServiceBuilder UseResourceAuthorization<TMessage, TResource, TResponse>()` | `TrellisServiceBuilder` | **AOT-safe.** Registers the closed-generic `ResourceAuthorizationBehavior<TMessage, TResource, TResponse>` for the named command. Implies `UseMediator()`. |
+| `[RequiresUnreferencedCode] [RequiresDynamicCode] public TrellisServiceBuilder UseResourceAuthorization(params Assembly[] assemblies)` | `TrellisServiceBuilder` | Scans assemblies for `IAuthorizeResource<TResource>` commands and registers `ResourceAuthorizationBehavior<TMessage, TResource, TResponse>` for each (non-AOT). Implies `UseMediator()`. |
+| `public TrellisServiceBuilder UseClaimsActorProvider(Action<ClaimsActorOptions>? configure = null)` | `TrellisServiceBuilder` | Registers `ClaimsActorProvider` as `IActorProvider`. Mutually exclusive with the other actor-provider selectors; a second actor-provider selector throws `InvalidOperationException`. |
+| `public TrellisServiceBuilder UseNestedJsonPathClaimsActorProvider(Action<NestedJsonPathClaimsActorOptions>? configure = null)` | `TrellisServiceBuilder` | Registers `NestedJsonPathClaimsActorProvider` as `IActorProvider` with startup validation for the container-claim invariant. Mutually exclusive with the other actor-provider selectors; a second actor-provider selector throws `InvalidOperationException`. When `configure` is omitted, the default empty JSON paths make the provider behave like `ClaimsActorProvider`. |
+| `public TrellisServiceBuilder UseEntraActorProvider(Action<EntraActorOptions>? configure = null)` | `TrellisServiceBuilder` | Registers `EntraActorProvider` as `IActorProvider`. Mutually exclusive with the other actor-provider selectors; a second actor-provider selector throws `InvalidOperationException`. |
+| `public TrellisServiceBuilder UseDevelopmentActorProvider(Action<DevelopmentActorOptions>? configure = null)` | `TrellisServiceBuilder` | Registers `DevelopmentActorProvider` as `IActorProvider`. Mutually exclusive with the other actor-provider selectors; a second actor-provider selector throws `InvalidOperationException`. Use only in development/testing hosts. |
+| `public TrellisServiceBuilder UseCachingActorProvider<T>() where T : class, IActorProvider` | `TrellisServiceBuilder` | Wraps the inner `IActorProvider` registration with a per-request caching decorator via `AddCachingActorProvider<T>()`. Chain after the matching `UseXxxActorProvider(...)` call so the inner provider's `IOptions<TOptions>` is configured first. Throws `InvalidOperationException` on repeated call. |
+| `public TrellisServiceBuilder UseWorkerActor(Actor systemActor)` | `TrellisServiceBuilder` | Composes the unkeyed `IActorProvider` registration produced by the selected actor-provider slot with a worker-actor wrapper via `AddTrellisWorkerActor(systemActor)`. The wrapper returns `systemActor` when `IHttpContextAccessor.HttpContext` is `null` (background-worker ticks, hosted services) and delegates to the inner provider otherwise. `Apply()` always runs this after the actor-provider selection and any `UseCachingActorProvider<T>()` wrap, so worker-tick lookups bypass the caching layer regardless of the chain order in which `UseWorkerActor(...)` was called. Requires that some actor provider slot is selected somewhere in the composition (`UseClaimsActorProvider`, `UseNestedJsonPathClaimsActorProvider`, `UseEntraActorProvider`, `UseDevelopmentActorProvider`, or `UseCachingActorProvider<T>()` with a custom provider). Throws `InvalidOperationException` on repeated call, when no actor provider slot is selected, or when the inner descriptor is singleton-lifetime via implementation type or factory (use `services.AddSingleton<IActorProvider>(instance)` or re-register as scoped instead) or transient-lifetime (re-register as scoped). Keyed registrations are ignored. |
+| `[RequiresUnreferencedCode] [RequiresDynamicCode] public TrellisServiceBuilder UseEntityFrameworkUnitOfWork<TContext>() where TContext : DbContext` | `TrellisServiceBuilder` | Registers `EfUnitOfWork<TContext>` and `TransactionalCommandBehavior<,>` via `AddTrellisUnitOfWork<TContext>()`. Implies `UseMediator()` and is applied last. Annotated non-AOT because the underlying `Trellis.EntityFrameworkCore` package opts out of AOT/trim. Throws `InvalidOperationException` on repeated call — see "Common traps". |
+| `public TrellisServiceBuilder UseDomainEvents()` | `TrellisServiceBuilder` | **AOT-safe.** Registers `DomainEventDispatchBehavior<,>` and the default `IDomainEventPublisher` without scanning. Implies `UseMediator()`. Mutually exclusive with `UseTrackedAggregateDomainEvents(...)`. |
+| `public TrellisServiceBuilder UseDomainEvents<TEvent, THandler>() where TEvent : IDomainEvent where THandler : class, IDomainEventHandler<TEvent>` | `TrellisServiceBuilder` | **AOT-safe.** Registers `THandler` for `TEvent` and wires the dispatch behavior. Implies `UseMediator()`. Mutually exclusive with `UseTrackedAggregateDomainEvents(...)`. |
+| `[RequiresUnreferencedCode] [RequiresDynamicCode] public TrellisServiceBuilder UseDomainEvents(params Assembly[] assemblies)` | `TrellisServiceBuilder` | Scans assemblies for `IDomainEventHandler<TEvent>` implementations (non-AOT). Implies `UseMediator()`. Mutually exclusive with `UseTrackedAggregateDomainEvents(...)`. |
+| `public TrellisServiceBuilder UseTrackedAggregateDomainEvents()` | `TrellisServiceBuilder` | **AOT-safe.** Registers `TrackedAggregateDomainEventDispatchBehavior<,>` and the default `IDomainEventPublisher` without scanning. Implies `UseMediator()`. Mutually exclusive with `UseDomainEvents(...)`. |
+| `public TrellisServiceBuilder UseTrackedAggregateDomainEvents<TEvent, THandler>() where TEvent : IDomainEvent where THandler : class, IDomainEventHandler<TEvent>` | `TrellisServiceBuilder` | **AOT-safe.** Registers `THandler` for `TEvent` and wires the tracked dispatch behavior. Implies `UseMediator()`. Mutually exclusive with `UseDomainEvents(...)`. |
+| `[RequiresUnreferencedCode] [RequiresDynamicCode] public TrellisServiceBuilder UseTrackedAggregateDomainEvents(params Assembly[] assemblies)` | `TrellisServiceBuilder` | Scans assemblies for `IDomainEventHandler<TEvent>` implementations (non-AOT). Implies `UseMediator()`. Mutually exclusive with `UseDomainEvents(...)`. |
+
+## Behavior
+
+`AddTrellis(...)` records selected modules first and then applies them in this order:
+
+1. ASP integration.
+2. ProblemDetails customization (when `UseProblemDetails()` is selected).
+3. Idempotency-Key middleware DI (when `UseIdempotency(...)` is selected).
+4. Actor provider (the optional caching wrap that chains after it, then the optional worker-actor wrap that chains after caching).
+5. Mediator behaviors.
+6. Resource authorization (assembly scanning, when assemblies are supplied).
+7. FluentValidation adapter/scanning when selected.
+8. Domain event dispatch (registers `DomainEventDispatchBehavior<,>`, the default `IDomainEventPublisher`, and any scanned handlers).
+9. EF Core Unit of Work.
+
+That order preserves the important pipeline invariant: `TransactionalCommandBehavior<,>` is the innermost behavior, closest to the handler, so commit failures remain visible to outer logging/tracing/exception behaviors.
+
+### Order-independence for explicit resource-authorization registrations
+
+Explicit `services.AddResourceAuthorization<TMessage, TResource, TResponse>()` calls made BEFORE `AddTrellis(...)` are now order-independent. `AddTrellisBehaviors()` (called by `UseMediator()`) detects any pre-existing closed-generic `ResourceAuthorizationBehavior<TMessage, TResource, TResponse>` descriptors and re-positions them to sit immediately before `ValidationBehavior<,>`, so they end up in the canonical pipeline envelope regardless of registration order. This mirrors the symmetry between `AddTrellisUnitOfWork<TContext>` and `AddDomainEventDispatch`.
+
+`AddTrellis(...)` deliberately does **not** register:
+
+- `AddDbContext<TContext>(...)` — provider, connection string, pooling, migrations, and interceptors are application-owned.
+- `AddMediator(...)` — handler discovery/source-generator configuration is application-owned.
+- route constraints — route parameter names are application-owned.
+
+## Examples
+
+```csharp
+// Error-to-status mapping only (no scalar-value JSON / model-binding wiring).
+services.AddTrellis(options => options.UseAsp());
+```
+
+```csharp
+// Controller-host default: error mapping + scalar-value validation.
+services.AddTrellis(options => options
+    .UseAsp()
+    .UseScalarValueValidation()
+    .UseMediator()
+    .UseFluentValidation(typeof(Program).Assembly));
+```
+
+```csharp
+// Adapter only; validators are registered explicitly elsewhere.
+services.AddTrellis(options => options
+    .UseMediator()
+    .UseFluentValidation());
+```
+
+```csharp
+// No assembly scanning; resource authorization registrations are explicit elsewhere.
+services.AddTrellis(options => options
+    .UseMediator()
+    .UseResourceAuthorization());
+```
+
+```csharp
+services.AddTrellis(options => options
+    .UseAsp()
+    .UseScalarValueValidation()
+    .UseMediator()
+    .UseClaimsActorProvider()
+    .UseResourceAuthorization(typeof(Program).Assembly)
+    .UseEntityFrameworkUnitOfWork<AppDbContext>());
+```
+
+```csharp
+// Domain event dispatch with assembly scanning. Handlers fire after the transaction
+// commits because UseDomainEvents is applied before UseEntityFrameworkUnitOfWork.
+services.AddTrellis(options => options
+    .UseMediator()
+    .UseDomainEvents(typeof(Program).Assembly)
+    .UseEntityFrameworkUnitOfWork<AppDbContext>());
+```

--- a/.github/trellis-api-testing.md
+++ b/.github/trellis-api-testing.md
@@ -1,0 +1,559 @@
+﻿---
+package: Trellis.Testing
+namespaces: [Trellis.Testing]
+types: ["FakeRepository<TAggregate, TId>", "FakeSharedResourceLoader<TResource, TId>", TestActorProvider, TestActorScope, "ResultAssertions<TValue>", ResultAssertionsExtensions, ResultAssertionsAsyncExtensions, IResultAssertions, IResultAssertionsExtensions, "MaybeAssertions<T>", MaybeAssertionsExtensions, ErrorAssertions, ErrorAssertionsExtensions, ValidationErrorAssertions, ValidationErrorAssertionsExtensions, UnwrapExtensions, UnwrapFailedException, AggregateTestMutator]
+version: v3
+last_verified: 2026-06-03
+audience: [llm]
+---
+# Trellis.Testing — API Reference
+
+- **Package:** `Trellis.Testing`
+- **Namespace:** `Trellis.Testing`
+- **Purpose:** FluentAssertions extensions, unwrap helpers, and test doubles (FakeRepository, TestActorProvider) for Trellis applications.
+
+See also: [trellis-api-cookbook.md](trellis-api-cookbook.md#recipe-10--test-handler-test-using-trellistesting-shouldbe--unwraperror) — recipes using this package.
+
+> **ASP.NET Core integration test helpers** (WebApplicationFactory, DI replacement, fake time, MSAL tokens, and `.http` replay) are in a separate package: [`Trellis.Testing.AspNetCore`](trellis-api-testing-aspnetcore.md#use-this-file-when).
+
+## Use this file when
+
+- You are writing unit/handler/domain tests for Trellis `Result`, `Maybe`, errors, or mediator handlers.
+- You need FluentAssertions extensions for success/failure/error-shape assertions.
+- You need test-only unwrap helpers, fake repositories, or test actor providers.
+
+## Patterns Index
+
+| Goal | Canonical API / pattern | See |
+|---|---|---|
+| Assert a generic result succeeded | `result.Should().BeSuccess()` / `.HaveValue(...)` | [`ResultAssertions<TValue>`](#resultassertionstvalue) |
+| Assert a result failed with a specific error case | `result.Should().BeFailureOfType<TError>()` | [`ResultAssertions<TValue>`](#resultassertionstvalue) |
+| Assert error code/detail | `.HaveErrorCode(...)`, `.HaveErrorDetail(...)`, `.HaveErrorDetailContaining(...)` | [`ResultAssertions<TValue>`](#resultassertionstvalue) |
+| Assert against `IResult` (e.g., `IAuthorizeResource<T>.Authorize` return value) | `result.Should().BeSuccess()` / `.BeFailureOfType<TError>()` — same surface, no `.HaveValue` since the non-generic interface carries no typed value | [`IResultAssertions`](#iresultassertions) |
+| Extract success value in tests only | `result.Unwrap()` | [Usage notes](#usage-notes) |
+| Extract error in tests only | `result.UnwrapError()` | [Usage notes](#usage-notes) |
+| Provide an actor in handler tests | `TestActorProvider` | [`TestActorProvider`](#testactorprovider) |
+| Stub repository behavior | `FakeRepository<TAggregate,TId>` | [`FakeRepository<TAggregate,TId>`](#fakerepositorytaggregate-tid) |
+
+## Common traps
+
+- `Unwrap()` and `UnwrapError()` are test helpers. Do not copy them into production code or documentation snippets for application logic.
+- Test both the success path and the expected error branch; a compiling handler that never asserts failure semantics can still miss Trellis behavior.
+- ASP.NET Core integration helpers are in [trellis-api-testing-aspnetcore.md](trellis-api-testing-aspnetcore.md#use-this-file-when), not this package.
+
+## Types
+
+### Namespace `Trellis.Testing`
+
+#### `ResultAssertionsExtensions`
+```csharp
+public static class ResultAssertionsExtensions
+{
+    public static ResultAssertions<TValue> Should<TValue>(this Result<TValue> result);
+}
+```
+
+#### `ResultAssertions<TValue>`
+```csharp
+public class ResultAssertions<TValue> : ReferenceTypeAssertions<Result<TValue>, ResultAssertions<TValue>>
+{
+    public ResultAssertions(Result<TValue> result);
+
+    public AndWhichConstraint<ResultAssertions<TValue>, TValue> BeSuccess(
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndWhichConstraint<ResultAssertions<TValue>, Error> BeFailure(
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndWhichConstraint<ResultAssertions<TValue>, TError> BeFailureOfType<TError>(
+        string because = "",
+        params object[] becauseArgs)
+        where TError : Error;
+
+    public AndConstraint<ResultAssertions<TValue>> HaveValue(
+        TValue expectedValue,
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndConstraint<ResultAssertions<TValue>> HaveValueMatching(
+        Func<TValue, bool> predicate,
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndConstraint<ResultAssertions<TValue>> HaveValueEquivalentTo(
+        TValue expectedValue,
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndConstraint<ResultAssertions<TValue>> HaveErrorCode(
+        string expectedCode,
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndConstraint<ResultAssertions<TValue>> HaveErrorDetail(
+        string expectedDetail,
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndConstraint<ResultAssertions<TValue>> HaveErrorDetailContaining(
+        string substring,
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndConstraint<ResultAssertions<TValue>> Be(
+        Result<TValue> expected,
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndConstraint<ResultAssertions<TValue>> NotBe(
+        Result<TValue> unexpected,
+        string because = "",
+        params object[] becauseArgs);
+}
+```
+
+#### `IResultAssertionsExtensions`
+
+```csharp
+public static class IResultAssertionsExtensions
+{
+    public static IResultAssertions Should(this IResult result);
+}
+```
+
+#### `IResultAssertions`
+
+Entry-point for assertions against members typed as the non-generic `IResult` interface — most commonly `IAuthorizeResource<TResource>.Authorize` and `IAuthorizeResourceVia<TOwner>.Authorize`, which both return `IResult` by contract. Mirrors the failure-side surface of `ResultAssertions<TValue>` (no `.HaveValue` because the non-generic interface carries no typed value).
+
+Overload resolution: a concrete `Result<T>` always binds to the typed `Should<T>(this Result<T>)` extension instead (struct is more specific than the `IResult` interface). The non-generic entry point fires for any receiver statically typed as `IResult` — including `IResult<TValue>`, generic type parameters constrained to `IResult`, and custom concrete types implementing `IResult` — because no typed extension exists for those receivers. Consumers holding `IResult<TValue>` who want the typed `.HaveValue` surface should narrow the receiver to a concrete `Result<TValue>` first.
+
+```csharp
+public class IResultAssertions : ReferenceTypeAssertions<IResult, IResultAssertions>
+{
+    public IResultAssertions(IResult result);
+
+    public AndConstraint<IResultAssertions> BeSuccess(
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndWhichConstraint<IResultAssertions, Error> BeFailure(
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndWhichConstraint<IResultAssertions, TError> BeFailureOfType<TError>(
+        string because = "",
+        params object[] becauseArgs)
+        where TError : Error;
+
+    public AndConstraint<IResultAssertions> HaveErrorCode(
+        string expectedCode,
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndConstraint<IResultAssertions> HaveErrorDetail(
+        string expectedDetail,
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndConstraint<IResultAssertions> HaveErrorDetailContaining(
+        string substring,
+        string because = "",
+        params object[] becauseArgs);
+}
+```
+
+#### `UnwrapError(this Result<Unit>)`
+The `UnwrapError` extension also has a `Result<Unit>`-specific overload at `Trellis.Testing.UnwrapExtensions.UnwrapError(this Result<Unit>)` for tests asserting on no-payload results.
+
+#### `ResultAssertionsAsyncExtensions`
+```csharp
+public static class ResultAssertionsAsyncExtensions
+{
+    public static Task<AndWhichConstraint<ResultAssertions<TValue>, TValue>> BeSuccessAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        string because = "",
+        params object[] becauseArgs);
+
+    public static Task<AndWhichConstraint<ResultAssertions<TValue>, Error>> BeFailureAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        string because = "",
+        params object[] becauseArgs);
+
+    public static Task<AndWhichConstraint<ResultAssertions<TValue>, TError>> BeFailureOfTypeAsync<TValue, TError>(
+        this Task<Result<TValue>> resultTask,
+        string because = "",
+        params object[] becauseArgs)
+        where TError : Error;
+
+    public static ValueTask<AndWhichConstraint<ResultAssertions<TValue>, TValue>> BeSuccessAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        string because = "",
+        params object[] becauseArgs);
+
+    public static ValueTask<AndWhichConstraint<ResultAssertions<TValue>, Error>> BeFailureAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        string because = "",
+        params object[] becauseArgs);
+
+    public static ValueTask<AndWhichConstraint<ResultAssertions<TValue>, TError>> BeFailureOfTypeAsync<TValue, TError>(
+        this ValueTask<Result<TValue>> resultTask,
+        string because = "",
+        params object[] becauseArgs)
+        where TError : Error;
+}
+```
+
+#### `MaybeAssertionsExtensions`
+```csharp
+public static class MaybeAssertionsExtensions
+{
+    public static MaybeAssertions<T> Should<T>(this Maybe<T> maybe)
+        where T : notnull;
+}
+```
+
+#### `MaybeAssertions<T>`
+```csharp
+public class MaybeAssertions<T> : ReferenceTypeAssertions<Maybe<T>, MaybeAssertions<T>>
+    where T : notnull
+{
+    public MaybeAssertions(Maybe<T> maybe);
+
+    public AndWhichConstraint<MaybeAssertions<T>, T> HaveValue(
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndConstraint<MaybeAssertions<T>> BeNone(
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndConstraint<MaybeAssertions<T>> HaveValueEqualTo(
+        T expectedValue,
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndConstraint<MaybeAssertions<T>> HaveValueMatching(
+        Func<T, bool> predicate,
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndConstraint<MaybeAssertions<T>> HaveValueEquivalentTo(
+        T expectedValue,
+        string because = "",
+        params object[] becauseArgs);
+}
+```
+
+#### `ErrorAssertionsExtensions`
+```csharp
+public static class ErrorAssertionsExtensions
+{
+    public static ErrorAssertions Should(this Error? error);
+}
+```
+
+#### `ErrorAssertions`
+```csharp
+public class ErrorAssertions : ReferenceTypeAssertions<Error, ErrorAssertions>
+{
+    public ErrorAssertions(Error error);
+
+    public AndConstraint<ErrorAssertions> Be(
+        Error expected,
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndConstraint<ErrorAssertions> HaveCode(
+        string expectedCode,
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndConstraint<ErrorAssertions> HaveDetail(
+        string expectedDetail,
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndConstraint<ErrorAssertions> HaveDetailContaining(
+        string substring,
+        string because = "",
+        params object[] becauseArgs);
+
+    public new AndWhichConstraint<ErrorAssertions, TError> BeOfType<TError>(
+        string because = "",
+        params object[] becauseArgs)
+        where TError : Error;
+}
+```
+
+> **Note:** The `HaveInstance(...)` assertion was removed. `Error.Instance` is no longer part of the closed-ADT base — the ASP wire layer populates `ProblemDetails.Instance` from the server-relative request path+query, and typed payloads expose `ResourceRef` (e.g. `Error.NotFound.Resource`) directly for assertion via `BeOfType<Error.NotFound>().Which.Resource`.
+
+#### `ValidationErrorAssertionsExtensions`
+```csharp
+public static class ValidationErrorAssertionsExtensions
+{
+    // Bound to Error.InvalidInput (the replacement for the previous validation error class).
+    // Method names preserved for source-compat at test sites.
+    public static ValidationErrorAssertions Should(this Error.InvalidInput error);
+}
+```
+
+#### `ValidationErrorAssertions`
+```csharp
+public class ValidationErrorAssertions : ReferenceTypeAssertions<Error.InvalidInput, ValidationErrorAssertions>
+{
+    public ValidationErrorAssertions(Error.InvalidInput error);
+
+    public AndConstraint<ValidationErrorAssertions> HaveFieldError(
+        string fieldName,                              // accepted as either "email" or "/email" — normalized via InputPointer.ForProperty
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndConstraint<ValidationErrorAssertions> HaveFieldErrorWithDetail(
+        string fieldName,
+        string expectedDetail,                         // matches FieldViolation.Detail exactly
+        string because = "",
+        params object[] becauseArgs);
+
+    public AndConstraint<ValidationErrorAssertions> HaveFieldCount(
+        int expectedCount,                             // counts distinct field paths
+        string because = "",
+        params object[] becauseArgs);
+}
+```
+
+#### `UnwrapExtensions`
+```csharp
+public static class UnwrapExtensions
+{
+    public static T Unwrap<T>(this Result<T> result);
+
+    public static Error UnwrapError<T>(this Result<T> result);
+
+    public static Error UnwrapError(this Result<Unit> result);
+
+    public static T Unwrap<T>(this Maybe<T> maybe)
+        where T : notnull;
+
+    public static Task<T> UnwrapAsync<T>(this Task<Result<T>> resultTask);
+
+    public static ValueTask<T> UnwrapAsync<T>(this ValueTask<Result<T>> resultTask);
+}
+```
+
+#### `UnwrapFailedException`
+```csharp
+public sealed class UnwrapFailedException : Exception
+{
+    public UnwrapFailedException();
+    public UnwrapFailedException(string message);
+    public UnwrapFailedException(string message, Exception innerException);
+}
+```
+
+#### `AggregateTestMutator`
+```csharp
+public static class AggregateTestMutator
+{
+    [RequiresUnreferencedCode("Uses reflection to set source-generated backing fields. Not AOT-compatible — test-only.")]
+    public static TEntity SetMaybeField<TEntity, TValue>(
+        this TEntity entity,
+        Expression<Func<TEntity, Maybe<TValue>>> propertySelector,
+        TValue? value)
+        where TEntity : class
+        where TValue : notnull;
+
+    [RequiresUnreferencedCode("Uses reflection to set source-generated backing fields. Not AOT-compatible — test-only.")]
+    public static TEntity ClearMaybeField<TEntity, TValue>(
+        this TEntity entity,
+        Expression<Func<TEntity, Maybe<TValue>>> propertySelector)
+        where TEntity : class
+        where TValue : notnull;
+}
+```
+
+> **AOT/trim incompatibility.** `AggregateTestMutator` uses reflection to set source-generated `Maybe<T>` backing fields. Both methods carry `[RequiresUnreferencedCode]`; AOT-published consumers will receive IL2026 / IL3050 warnings at the call site. The helpers are intentionally test-only — do not call them from production code.
+
+#### `FakeRepository<TAggregate, TId>`
+```csharp
+public class FakeRepository<TAggregate, TId>
+    where TAggregate : Aggregate<TId>
+    where TId : notnull
+{
+    public IReadOnlyList<IDomainEvent> PublishedEvents { get; }
+    public int Count { get; }
+
+    public FakeRepository<TAggregate, TId> WithUniqueConstraint(Func<TAggregate, object?> propertySelector);
+
+    public Task<Result<TAggregate>> GetByIdAsync(TId id, CancellationToken cancellationToken = default);
+    public Task<Maybe<TAggregate>> FindByIdAsync(TId id, CancellationToken cancellationToken = default);
+
+    // Read surface mirroring RepositoryBase<TAggregate, TId>. Use these from test
+    // repository adapters that expose specification-based queries.
+    public Task<IReadOnlyList<TAggregate>> QueryAsync(
+        Specification<TAggregate> specification,
+        CancellationToken cancellationToken = default);
+    public Task<bool> ExistsAsync(TId id, CancellationToken cancellationToken = default);
+    public Task<bool> ExistsAsync(
+        Specification<TAggregate> specification,
+        CancellationToken cancellationToken = default);
+    public Task<int> CountAsync(
+        Specification<TAggregate> specification,
+        CancellationToken cancellationToken = default);
+
+    // Setup surface — mirrors RepositoryBase<TAggregate, TId>. Use these in handlers and
+    // in test setup so the same IRepository contract works in both the EF and fake paths.
+    // Both Add and Remove (and DeleteAsync below) capture aggregate.UncommittedEvents()
+    // into PublishedEvents and call AcceptChanges, so deletion-related domain events
+    // are observable through PublishedEvents.
+    public void Add(TAggregate aggregate);
+    public void Remove(TAggregate aggregate);
+    public Task<Result<Unit>> RemoveByIdAsync(TId id, CancellationToken cancellationToken = default);
+
+    // Result-shape surface — only on the fake. Reserve for tests that explicitly assert
+    // on Result-of-save shape (e.g., conflict-result handling). NOT part of RepositoryBase.
+    public Task<Result<Unit>> SaveAsync(TAggregate aggregate, CancellationToken cancellationToken = default);
+    public Task<Result<Unit>> DeleteAsync(TId id, CancellationToken cancellationToken = default);
+
+    public void Clear();
+    public bool Exists(TId id);
+    public TAggregate? Get(TId id);
+    public IEnumerable<TAggregate> GetAll();
+
+    // Predicate/specification-based local helpers. Prefer the RepositoryBase-shaped
+    // QueryAsync/ExistsAsync/CountAsync above when building same-contract test adapters;
+    // these remain available for legacy test code and ad-hoc Func-based filtering.
+    public Task<Maybe<TAggregate>> FindAsync(Func<TAggregate, bool> predicate);
+    public Task<IReadOnlyList<TAggregate>> WhereAsync(Func<TAggregate, bool> predicate);
+    public Task<IReadOnlyList<TAggregate>> WhereAsync(Specification<TAggregate> specification);
+}
+```
+
+> **Cancellation token observability.** All `*Async` methods on `FakeRepository<TAggregate, TId>` accept a `CancellationToken` parameter for source-compat with `RepositoryBase<TAggregate, TId>` but **do not observe it** — the fake completes synchronously. Tests that rely on cancellation behavior need a different test double; this fake intentionally trades cancellation-observability for the simpler synchronous semantics that DDD aggregate tests typically need.
+
+> **Null guards.** `Add`, `Remove`, `SaveAsync`, `WithUniqueConstraint`, `QueryAsync`, `ExistsAsync(Specification<TAggregate>)`, `CountAsync`, `FindAsync`, and `WhereAsync` all `ArgumentNullException.ThrowIfNull(...)` their reference-type parameters. `GetByIdAsync`, `FindByIdAsync`, `RemoveByIdAsync`, `DeleteAsync`, and `ExistsAsync(TId)` rely on the `TId : notnull` constraint at compile time.
+
+#### `FakeSharedResourceLoader<TResource, TId>`
+```csharp
+public class FakeSharedResourceLoader<TResource, TId> : SharedResourceLoaderById<TResource, TId>
+    where TResource : Aggregate<TId>
+    where TId : notnull
+{
+    public FakeSharedResourceLoader(FakeRepository<TResource, TId> repository);
+
+    public override Task<Result<TResource>> GetByIdAsync(TId id, CancellationToken cancellationToken);
+}
+```
+
+#### `TestActorProvider`
+```csharp
+public sealed class TestActorProvider : IActorProvider
+{
+    public TestActorProvider(Actor actor);
+    public TestActorProvider(string userId, params string[] permissions);
+
+    public Task<Maybe<Actor>> GetCurrentActorAsync(CancellationToken cancellationToken = default);
+
+    public TestActorScope WithActor(Actor actor);
+    public TestActorScope WithActor(string userId, params string[] permissions);
+}
+```
+
+#### `TestActorScope`
+```csharp
+public sealed class TestActorScope : IAsyncDisposable, IDisposable
+{
+    public ValueTask DisposeAsync();
+    public void Dispose();
+}
+```
+
+## Usage notes
+
+### Assertions
+
+- Synchronous assertions start from `Result<T>` or `Maybe<T>`:
+  - `result.Should().BeSuccess()`
+  - `result.Should().BeFailureOfType<Error.InvalidInput>()`
+  - `maybe.Should().HaveValue()`
+- **Async assertions are extension methods on `Task<Result<T>>` and `ValueTask<Result<T>>`, not on `ResultAssertions<T>`.**
+  - Correct: `await resultTask.BeSuccessAsync();`
+  - Correct: `await valueTaskResult.BeFailureAsync();`
+  - Wrong: `await result.Should().BeSuccessAsync();`
+
+### FakeRepository
+
+- **Setup surface** (mirrors `RepositoryBase<TAggregate, TId>` in `Trellis.EntityFrameworkCore`) — use these from handlers and test setup so the same `IRepository` contract works in both worlds:
+  - `void Add(TAggregate)` — stages an insert; in the fake, immediately visible. Throws `InvalidOperationException` on unique-constraint violation (setup mistakes should fail loud at the call site).
+  - `void Remove(TAggregate)` — stages a delete; no-op if the aggregate is not in the store.
+  - `Task<Result<Unit>> RemoveByIdAsync(TId)` — looks up by ID and removes; returns `Error.NotFound` if missing.
+- **Result-shape surface** (only on the fake — `RepositoryBase` does not expose these) — use only when the test specifically asserts on the `Result` of the persistence call:
+  - `Task<Result<Unit>> SaveAsync(TAggregate)` — returns `Error.Conflict` on unique-constraint violation. Use to test conflict-handling code paths.
+  - `Task<Result<Unit>> DeleteAsync(TId)` — returns `Error.NotFound` on missing. Use to test not-found handling. (`RemoveByIdAsync` is the staging-API-named alias.)
+- `WithUniqueConstraint(Func<TAggregate, object?> propertySelector)` — fluent constraint registration; checked eagerly by `Add` (throws) and at-call by `SaveAsync` (returns `Result`).
+- `Clear()`, `Exists(TId id)`, `Get(TId id)`, `GetAll()`, `Count` — direct inspection helpers
+- `GetByIdAsync` / `DeleteAsync` / `RemoveByIdAsync` return `Error.NotFound` details in the EF-runtime format:
+  - `"{AggregateTypeName} with ID '{id}' not found."`
+- Unique-constraint conflicts return `Error.Conflict` with `ReasonCode` `"duplicate.key"` and detail:
+  - `"A {AggregateTypeName} with the same value already exists."`
+
+> See cookbook **Recipe 16 — Unit of work in handlers** for guidance on which surface to use from where, and the pitfall of accidentally calling `SaveAsync` from a production-shaped repository contract.
+
+## Compilable examples
+
+### Result assertions
+
+```csharp
+using FluentAssertions;
+using Trellis;
+using Trellis.Testing;
+
+var success = Result.Ok(42);
+success.Should().BeSuccess().Which.Should().Be(42);
+
+var notFound = Result.Fail<int>(new Error.NotFound(ResourceRef.For("Order", "123")) { Detail = "Order 123 not found" });
+notFound.Should().BeFailure()
+    .Which.Detail.Should().Be("Order 123 not found");
+```
+
+### Async assertions
+
+```csharp
+using System.Threading.Tasks;
+using FluentAssertions;
+using Trellis;
+using Trellis.Testing;
+
+Task<Result<int>> resultTask = Task.FromResult(Result.Ok(42));
+ValueTask<Result<int>> valueTaskResult = ValueTask.FromResult(Result.Ok(7));
+
+(await resultTask.BeSuccessAsync()).Which.Should().Be(42);
+(await valueTaskResult.BeSuccessAsync()).Which.Should().Be(7);
+```
+
+### FakeRepository
+
+```csharp
+using System;
+using FluentAssertions;
+using Trellis;
+using Trellis.Testing;
+
+public sealed record OrderId(Guid Value);
+
+public sealed class Order : Aggregate<OrderId>
+{
+    public Order(OrderId id) : base(id) { }
+}
+
+var repo = new FakeRepository<Order, OrderId>()
+    .WithUniqueConstraint(order => order.Id);
+
+var order = new Order(new OrderId(Guid.NewGuid()));
+
+await repo.SaveAsync(order).BeSuccessAsync();
+(await repo.GetByIdAsync(order.Id)).Should().BeSuccess().Which.Should().BeSameAs(order);
+repo.Exists(order.Id).Should().BeTrue();
+repo.Count.Should().Be(1);
+```

--- a/.gitignore
+++ b/.gitignore
@@ -363,4 +363,6 @@ MigrationBackup/
 FodyWeavers.xsd
 # Transitive duplicate of trellis-api-testing.md shipped by Trellis.Testing package build
 .github/trellis-api-testing-reference.md
+# trellis-api-efcore.md is shipped transitively but BuberDinner does not reference Trellis.EntityFrameworkCore
+.github/trellis-api-efcore.md
 

--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+# Transitive duplicate of trellis-api-testing.md shipped by Trellis.Testing package build
+.github/trellis-api-testing-reference.md
+

--- a/Api/src/2022-12-21/Controllers/MenuReviewsController.cs
+++ b/Api/src/2022-12-21/Controllers/MenuReviewsController.cs
@@ -1,0 +1,136 @@
+namespace BuberDinner._2022_12_21.Controllers;
+
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Asp.Versioning;
+using BuberDinner.Api._2022_12_21.Models.MenuReviews;
+using BuberDinner.Application.MenuReviews.Commands;
+using BuberDinner.Application.MenuReviews.Queries;
+using BuberDinner.Domain.Menu.ValueObject;
+using BuberDinner.Domain.MenuReview.Entities;
+using BuberDinner.Domain.MenuReview.ValueObject;
+using BuberDinner.Domain.User.ValueObjects;
+using Mapster;
+using Mediator;
+using Microsoft.AspNetCore.Mvc;
+using Trellis;
+using Trellis.Asp;
+
+/// <summary>Menu review endpoints.</summary>
+[ApiVersion("2022-10-01")]
+[Route("menu-reviews")]
+[Produces("application/json")]
+[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+public class MenuReviewsController : ControllerBase
+{
+    private readonly ISender _sender;
+
+    /// <summary>Initialises a new <see cref="MenuReviewsController"/>.</summary>
+    public MenuReviewsController(ISender sender)
+    {
+        _sender = sender;
+    }
+
+    /// <summary>Submit a review for a menu. Validated by FluentValidation at the Mediator pipeline.</summary>
+    [HttpPost]
+    [Consumes("application/json")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
+    public async ValueTask<ActionResult<MenuReviewResponse>> SubmitReview(
+        [FromBody] SubmitMenuReviewRequest request,
+        CancellationToken cancellationToken)
+    {
+        var guestIdResult = ResolveCallerGuestId();
+        if (guestIdResult.IsFailure)
+            return Unauthorized();
+        var guestId = guestIdResult.GetValueOrThrow("guestId");
+
+        return await request.ToSubmitMenuReviewCommand(guestId)
+            .BindAsync(command => _sender.Send(command, cancellationToken))
+            .ToHttpResponseAsync(
+                body: review => review.Adapt<MenuReviewResponse>(),
+                configure: opts => opts
+                    .Created(review => $"/menu-reviews/{review.Id.Value}")
+                    .WithETag(review => EntityTagValue.Strong(review.ETag)))
+            .AsActionResultAsync<MenuReviewResponse>();
+    }
+
+    /// <summary>Get a single review.</summary>
+    [HttpGet("{reviewId:MenuReviewId}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status304NotModified)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async ValueTask<ActionResult<MenuReviewResponse>> GetReview(
+        MenuReviewId reviewId, CancellationToken cancellationToken) =>
+        await _sender.Send(new GetMenuReviewQuery(reviewId), cancellationToken)
+            .ToHttpResponseAsync(
+                body: review => review.Adapt<MenuReviewResponse>(),
+                configure: opts => opts
+                    .WithETag(review => EntityTagValue.Strong(review.ETag))
+                    .EvaluatePreconditions())
+            .AsActionResultAsync<MenuReviewResponse>();
+
+    /// <summary>Update an existing review. Only the owning guest can update.</summary>
+    [HttpPut("{reviewId:MenuReviewId}")]
+    [Consumes("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
+    public async ValueTask<ActionResult<MenuReviewResponse>> UpdateReview(
+        MenuReviewId reviewId,
+        [FromBody] UpdateMenuReviewRequest request,
+        CancellationToken cancellationToken)
+    {
+        var guestIdResult = ResolveCallerGuestId();
+        if (guestIdResult.IsFailure)
+            return Unauthorized();
+        var guestId = guestIdResult.GetValueOrThrow("guestId");
+
+        var command = new UpdateMenuReviewCommand(reviewId, guestId, request.Rating, request.Comment ?? string.Empty);
+        return await _sender.Send(command, cancellationToken)
+            .ToHttpResponseAsync(
+                body: review => review.Adapt<MenuReviewResponse>(),
+                configure: opts => opts.WithETag(review => EntityTagValue.Strong(review.ETag)))
+            .AsActionResultAsync<MenuReviewResponse>();
+    }
+
+    /// <summary>Paginated list of reviews for a menu.</summary>
+    [HttpGet("for-menu/{menuId:MenuId}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
+    public async ValueTask<ActionResult<PagedResponse<MenuReviewResponse>>> ListReviewsForMenu(
+        MenuId menuId,
+        [FromQuery(Name = "cursor")] string? cursor,
+        [FromQuery(Name = "limit")] int? limit,
+        CancellationToken cancellationToken)
+    {
+        var origin = $"{Request.Scheme}://{Request.Host}";
+        var basePath = $"{origin}/menu-reviews/for-menu/{menuId.Value}";
+        var apiVersion = HttpContext.GetRequestedApiVersion()?.ToString() ?? "2022-10-01";
+
+        return await _sender.Send(
+                new ListReviewsForMenuQuery(
+                    menuId,
+                    cursor is { Length: > 0 } token ? new Cursor(token) : (Cursor?)null,
+                    limit),
+                cancellationToken)
+            .ToHttpResponseAsync(
+                nextUrlBuilder: (nextCursor, appliedLimit) =>
+                    $"{basePath}?cursor={Uri.EscapeDataString(nextCursor.Token)}&limit={appliedLimit}&api-version={apiVersion}",
+                body: review => review.Adapt<MenuReviewResponse>())
+            .AsActionResultAsync<PagedResponse<MenuReviewResponse>>();
+    }
+
+    private Result<UserId> ResolveCallerGuestId()
+    {
+        var raw = HttpContext.User.FindFirst("sub")?.Value
+                  ?? HttpContext.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (string.IsNullOrEmpty(raw))
+            return Result.Fail<UserId>(new Error.AuthenticationRequired());
+        return UserId.TryCreate(raw);
+    }
+}

--- a/Api/src/2022-12-21/Models/MenuReviews/MenuReviewDtos.cs
+++ b/Api/src/2022-12-21/Models/MenuReviews/MenuReviewDtos.cs
@@ -1,0 +1,44 @@
+namespace BuberDinner.Api._2022_12_21.Models.MenuReviews;
+
+using System;
+using BuberDinner.Application.MenuReviews.Commands;
+using BuberDinner.Domain.MenuReview.Entities;
+using BuberDinner.Domain.User.ValueObjects;
+using Mapster;
+using DinnerIdClass = BuberDinner.Domain.Dinner.ValueObject.DinnerId;
+using MenuIdClass = BuberDinner.Domain.Menu.ValueObject.MenuId;
+
+/// <summary>Wire shape for a menu review.</summary>
+public record MenuReviewResponse(
+    string Id,
+    string MenuId,
+    string DinnerId,
+    string GuestUserId,
+    int Rating,
+    string Comment);
+
+/// <summary>POST /menu-reviews body.</summary>
+public record SubmitMenuReviewRequest(string MenuId, string DinnerId, int Rating, string Comment)
+{
+    /// <summary>Lifts the request into a validated command via the Result pipeline.</summary>
+    public Result<SubmitMenuReviewCommand> ToSubmitMenuReviewCommand(UserId guestUserId) =>
+        MenuIdClass.TryCreate(this.MenuId, nameof(MenuId))
+            .Combine(DinnerIdClass.TryCreate(this.DinnerId, nameof(DinnerId)))
+            .Map((menuId, dinnerId) =>
+                new SubmitMenuReviewCommand(menuId, dinnerId, guestUserId, this.Rating, this.Comment));
+}
+
+/// <summary>PUT /menu-reviews/{id} body.</summary>
+public record UpdateMenuReviewRequest(int Rating, string Comment);
+
+/// <summary>Mapster registration for MenuReview → MenuReviewResponse.</summary>
+public sealed class MenuReviewMappingConfig : IRegister
+{
+    /// <inheritdoc />
+    public void Register(TypeAdapterConfig config) =>
+        config.NewConfig<MenuReview, MenuReviewResponse>()
+            .Map(dest => dest.Id, src => src.Id.Value.ToString())
+            .Map(dest => dest.MenuId, src => src.MenuId.Value.ToString())
+            .Map(dest => dest.DinnerId, src => src.DinnerId.Value.ToString())
+            .Map(dest => dest.GuestUserId, src => src.GuestUserId.Value);
+}

--- a/Api/src/BuberDinner.Api.csproj
+++ b/Api/src/BuberDinner.Api.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" />
     <PackageReference Include="Trellis.Asp" />
+    <PackageReference Include="Trellis.ServiceDefaults" />
     <PackageReference Include="Mapster" />
     <PackageReference Include="Mapster.DependencyInjection" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />

--- a/Api/src/DependencyInjection.cs
+++ b/Api/src/DependencyInjection.cs
@@ -3,12 +3,16 @@
 using System.Reflection;
 using BuberDinner.Application.Dinners.Events;
 using BuberDinner.Application.Hosts.Authorization;
+using BuberDinner.Application.MenuReviews.Events;
+using BuberDinner.Application.MenuReviews.Validators;
 using BuberDinner.Application.Menus.Commands;
 using BuberDinner.Application.Reservations.Events;
 using BuberDinner.Domain.Dinner.Events;
 using BuberDinner.Domain.Dinner.ValueObject;
 using BuberDinner.Domain.Host.ValueObject;
 using BuberDinner.Domain.Menu.ValueObject;
+using BuberDinner.Domain.MenuReview.Events;
+using BuberDinner.Domain.MenuReview.ValueObject;
 using BuberDinner.Domain.Reservation.Events;
 using BuberDinner.Domain.Reservation.ValueObject;
 using Mapster;
@@ -17,110 +21,89 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
-using Trellis.Asp;
-using Trellis.Asp.Authorization;
+using Trellis;
 using Trellis.Asp.Idempotency;
 using Trellis.Asp.Routing;
 using Trellis.Mediator;
+using Trellis.ServiceDefaults;
 
 internal static class DependencyInjection
 {
     public static IServiceCollection AddPresentation(this IServiceCollection services)
     {
         services.AddControllers();
-        services.AddTrellisAspWithScalarValidation();
 
-        // Scalar value-object route constraints — let MVC bind `{hostId:HostId}` / `{menuId:MenuId}`
-        // / `{dinnerId:DinnerId}` / `{reservationId:ReservationId}` straight into typed VOs at the boundary.
+        services.AddTrellis(t => t
+            .UseAsp()
+            .UseScalarValueValidation()
+            .UseProblemDetails()
+            .UseMediator()
+            .UseClaimsActorProvider(opts => opts.ActorIdClaim = "sub")
+            .UseResourceAuthorization(
+                typeof(UpdateMenuCommand).Assembly,
+                typeof(HostResourceLoader).Assembly)
+            .UseFluentValidation(typeof(SubmitMenuReviewCommandValidator).Assembly)
+            .UseDomainEvents()
+            .UseIdempotency(opts =>
+            {
+                opts.Ttl = TimeSpan.FromHours(24);
+                opts.MaxRequestBodyBytes = 256 * 1024;
+            }));
+        services.AddInMemoryIdempotencyStore();
+
         services.AddTrellisRouteConstraint<HostId>(nameof(HostId));
         services.AddTrellisRouteConstraint<MenuId>(nameof(MenuId));
         services.AddTrellisRouteConstraint<DinnerId>(nameof(DinnerId));
         services.AddTrellisRouteConstraint<ReservationId>(nameof(ReservationId));
+        services.AddTrellisRouteConstraint<MenuReviewId>(nameof(MenuReviewId));
 
-        // Resource-based authorization wiring: ClaimsActorProvider reads the JWT `sub` claim
-        // and the SharedResourceLoaderById<Host, HostId> in the Application assembly authorizes
-        // any command implementing IAuthorizeResource<Host> + IIdentifyResource<Host, HostId>.
-        services.AddClaimsActorProvider(opts => opts.ActorIdClaim = "sub");
-        services.AddResourceAuthorization(
-            typeof(UpdateMenuCommand).Assembly,   // Application — commands + IAuthorizeResource implementations
-            typeof(HostResourceLoader).Assembly); // Same assembly today; named for clarity / future ACL split
-
-        // Domain event dispatch (Cookbook Recipe 17): explicit per-handler registration is
-        // AOT-safe and surfaces intent at the registration site. Each Dinner state transition
-        // raises exactly one event; each event has a single side-effect-only logging handler.
-        services.AddDomainEventDispatch();
         services.AddDomainEventHandler<DinnerScheduled, LogDinnerScheduledHandler>();
         services.AddDomainEventHandler<DinnerStarted, LogDinnerStartedHandler>();
         services.AddDomainEventHandler<DinnerEnded, LogDinnerEndedHandler>();
         services.AddDomainEventHandler<DinnerCancelled, LogDinnerCancelledHandler>();
         services.AddDomainEventHandler<ReservationCreated, LogReservationCreatedHandler>();
         services.AddDomainEventHandler<ReservationCancelled, LogReservationCancelledHandler>();
+        services.AddDomainEventHandler<MenuReviewSubmitted, LogMenuReviewSubmittedHandler>();
+        services.AddDomainEventHandler<MenuReviewUpdated, LogMenuReviewUpdatedHandler>();
 
-        // IETF Idempotency-Key middleware wiring (Cookbook Recipe 29). The attribute on
-        // ReservationsController.CreateReservation opts THAT endpoint into the middleware;
-        // every other endpoint is a no-op. The in-memory store is single-process only —
-        // production hosts behind a load balancer need an EF-backed implementation that
-        // honours the same CAS contract.
-        services.AddTrellisIdempotency(opts =>
-        {
-            opts.Ttl = TimeSpan.FromHours(24);
-            opts.MaxRequestBodyBytes = 256 * 1024;
-        });
-        services.AddInMemoryIdempotencyStore();
-
-        // .NET 8 testable clock — handlers inject TimeProvider rather than DateTime.UtcNow so
-        // tests can pin the clock via FakeTimeProvider (Cookbook Recipe 17 §1319).
         services.AddSingleton(TimeProvider.System);
 
         services.AddMappings();
-        services.AddApiVersioning(
-                    options =>
-                    {
-                        options.ReportApiVersions = true;
-                    })
+        services.AddApiVersioning(options => options.ReportApiVersions = true)
                 .AddMvc()
                 .AddApiExplorer();
 
-        // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
         services.AddTransient<IConfigureOptions<SwaggerGenOptions>, ConfigureSwaggerOptions>();
-        services.AddSwaggerGen(
-            options =>
+        services.AddSwaggerGen(options =>
+        {
+            options.OperationFilter<SwaggerDefaultValues>();
+            var fileName = typeof(Program).Assembly.GetName().Name + ".xml";
+            var filePath = Path.Combine(AppContext.BaseDirectory, fileName);
+            options.IncludeXmlComments(filePath);
+            options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
             {
-                // add a custom operation filter which sets default values
-                options.OperationFilter<SwaggerDefaultValues>();
-
-                var fileName = typeof(Program).Assembly.GetName().Name + ".xml";
-                var filePath = Path.Combine(AppContext.BaseDirectory, fileName);
-
-                // integrate XML comments
-                options.IncludeXmlComments(filePath);
-
-                // Set up to allow specifying auth token when executing requests via swagger.
-                options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme()
-                {
-                    In = ParameterLocation.Header,
-                    Description = "Specify token",
-                    Name = "Authorization",
-                    Type = SecuritySchemeType.Http,
-                    BearerFormat = "JWT",
-                    Scheme = "bearer"
-                });
-
-                options.AddSecurityRequirement(new OpenApiSecurityRequirement()
-                {
-                    {
-                        new OpenApiSecurityScheme()
-                        {
-                            Reference = new OpenApiReference()
-                            {
-                                Type = ReferenceType.SecurityScheme,
-                                Id = "Bearer"
-                            }
-                        },
-                        Array.Empty<string>()
-                    }
-                });
+                In = ParameterLocation.Header,
+                Description = "Specify token",
+                Name = "Authorization",
+                Type = SecuritySchemeType.Http,
+                BearerFormat = "JWT",
+                Scheme = "bearer",
             });
+            options.AddSecurityRequirement(new OpenApiSecurityRequirement
+            {
+                {
+                    new OpenApiSecurityScheme
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.SecurityScheme,
+                            Id = "Bearer",
+                        },
+                    },
+                    Array.Empty<string>()
+                },
+            });
+        });
         return services;
     }
 
@@ -132,5 +115,4 @@ internal static class DependencyInjection
         services.AddScoped<IMapper, ServiceMapper>();
         return services;
     }
-
 }

--- a/Api/src/Program.cs
+++ b/Api/src/Program.cs
@@ -33,11 +33,6 @@ var app = builder.Build();
     app.UseRouting();
     app.UseAuthentication();
     app.UseAuthorization();
-    // Idempotency middleware MUST sit AFTER UseAuthentication/UseAuthorization so the default
-    // per-actor scope sees the authenticated Actor and partitions the store by it. Mounting
-    // before authentication would let every authenticated request fall back to the shared
-    // 'anonymous' scope, which can let different users collide on the same Idempotency-Key
-    // (trellis-api-asp.md:431).
     app.UseTrellisIdempotency();
     app.MapControllers().RequireAuthorization();
     app.Run();

--- a/Api/tests/2022-12-21/MenuReviewTests.cs
+++ b/Api/tests/2022-12-21/MenuReviewTests.cs
@@ -26,8 +26,8 @@ public class MenuReviewTests : IClassFixture<WebApplicationFactory<Program>>
     [Fact, Priority(6)]
     public async Task SubmitReview_returns_201_with_etag_and_location()
     {
-        var (_, _, _, _, menuId, dinnerId) = await SeedHostMenuAndDinnerAsync();
         var guest = await NewGuestClientAsync();
+        var (menuId, dinnerId) = await SeedReadyToReviewAsync(guest.client);
 
         var response = await PostReviewAsync(guest.client, menuId, dinnerId, rating: 4, comment: "Great brunch!");
 
@@ -88,8 +88,8 @@ public class MenuReviewTests : IClassFixture<WebApplicationFactory<Program>>
     [Fact, Priority(6)]
     public async Task UpdateReview_with_invalid_rating_returns_422_via_FluentValidation_before_handler_runs()
     {
-        var (_, _, _, _, menuId, dinnerId) = await SeedHostMenuAndDinnerAsync();
         var guest = await NewGuestClientAsync();
+        var (menuId, dinnerId) = await SeedReadyToReviewAsync(guest.client);
         var first = await PostReviewAsync(guest.client, menuId, dinnerId, rating: 3, comment: "okay");
         var id = (await first.Content.ReadAsAsync<ReviewBody>())!.Id;
 
@@ -104,8 +104,8 @@ public class MenuReviewTests : IClassFixture<WebApplicationFactory<Program>>
     [Fact, Priority(6)]
     public async Task UpdateReview_as_different_guest_returns_404_NotFound_leak_shield()
     {
-        var (_, _, _, _, menuId, dinnerId) = await SeedHostMenuAndDinnerAsync();
         var owner = await NewGuestClientAsync();
+        var (menuId, dinnerId) = await SeedReadyToReviewAsync(owner.client);
         var first = await PostReviewAsync(owner.client, menuId, dinnerId, rating: 4, comment: "ok");
         var id = (await first.Content.ReadAsAsync<ReviewBody>())!.Id;
 
@@ -119,8 +119,8 @@ public class MenuReviewTests : IClassFixture<WebApplicationFactory<Program>>
     [Fact, Priority(6)]
     public async Task ListReviewsForMenu_paginates()
     {
-        var (_, _, _, _, menuId, dinnerId) = await SeedHostMenuAndDinnerAsync();
         var guest = await NewGuestClientAsync();
+        var (menuId, dinnerId) = await SeedReadyToReviewAsync(guest.client);
         for (int i = 0; i < 7; i++)
             (await PostReviewAsync(guest.client, menuId, dinnerId, rating: 5, comment: $"Review {i}"))
                 .EnsureSuccessStatusCode();
@@ -140,7 +140,112 @@ public class MenuReviewTests : IClassFixture<WebApplicationFactory<Program>>
         p3.Next.Should().BeNull();
     }
 
+    [Fact, Priority(6)]
+    public async Task SubmitReview_against_missing_dinner_returns_404()
+    {
+        var (_, _, _, _, menuId, _) = await SeedHostMenuAndDinnerAsync();
+        var guest = await NewGuestClientAsync();
+        var phantomDinnerId = Guid.NewGuid().ToString();
+
+        var response = await PostReviewAsync(guest.client, menuId, phantomDinnerId, rating: 3, comment: "ok");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact, Priority(6)]
+    public async Task SubmitReview_against_dinner_not_matching_menu_returns_404_leak_shield()
+    {
+        var (hostClient, _, hostId, _, menuAId, dinnerForAId) = await SeedHostMenuAndDinnerAsync();
+        var menuBResp = await hostClient.PostAsync($"hosts/{hostId}/menus/create{ApiVersion}", JsonBody(new
+        {
+            name = "M-B",
+            description = "d",
+            sections = new[] { new { name = "s", description = "d", items = new[] { new { name = "i", description = "d" } } } },
+        }));
+        var menuBId = (await menuBResp.Content.ReadAsAsync<IdOnly>())!.Id;
+        var guest = await NewGuestClientAsync();
+
+        var response = await PostReviewAsync(guest.client, menuBId, dinnerForAId, rating: 4, comment: "wrong menu");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "the dinner-belongs-to-menu gate fires as 404 to avoid leaking dinner existence to callers querying with a mismatched menu");
+    }
+
+    [Fact, Priority(6)]
+    public async Task SubmitReview_without_reservation_returns_404_leak_shield()
+    {
+        var (_, _, _, _, menuId, dinnerId) = await SeedHostMenuAndDinnerAsync();
+        var guest = await NewGuestClientAsync();
+
+        var response = await PostReviewAsync(guest.client, menuId, dinnerId, rating: 4, comment: "ok");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "callers without a reservation get a leak-shielded 404 rather than a status-revealing 422");
+    }
+
+    [Fact, Priority(6)]
+    public async Task SubmitReview_against_upcoming_dinner_returns_422_review_dinner_not_ended()
+    {
+        var (_, _, _, _, menuId, dinnerId) = await SeedHostMenuAndDinnerAsync();
+        var guest = await NewGuestClientAsync();
+        await ReserveAsync(guest.client, dinnerId);
+
+        var response = await PostReviewAsync(guest.client, menuId, dinnerId, rating: 5, comment: "too early");
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        var problem = await response.Content.ReadAsAsync<ProblemWithRules>();
+        problem!.Rules.Should().NotBeNull().And.Subject!
+            .Should().ContainSingle().Which.Code.Should().Be("review.dinner-not-ended");
+    }
+
+    [Fact, Priority(6)]
+    public async Task SubmitReview_with_cancelled_reservation_returns_404_leak_shield()
+    {
+        var (hostClient, _, hostId, _, menuId, dinnerId) = await SeedHostMenuAndDinnerAsync();
+        var guest = await NewGuestClientAsync();
+        var reservationResp = await ReserveAsync(guest.client, dinnerId);
+        var reservationId = (await reservationResp.Content.ReadAsAsync<ReservationIdOnly>())!.Id;
+        (await guest.client.PostAsync($"reservations/{reservationId}/cancel{ApiVersion}",
+            JsonBody(new { reason = "changed-mind" }))).EnsureSuccessStatusCode();
+        await StartAndEndDinnerAsync(hostClient, hostId, dinnerId);
+
+        var response = await PostReviewAsync(guest.client, menuId, dinnerId, rating: 5, comment: "should be blocked");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "cancelled reservations don't count as 'reserved this dinner'");
+    }
+
     // ---------------- helpers ----------------
+
+    private async Task<(string menuId, string dinnerId)> SeedReadyToReviewAsync(HttpClient guestClient)
+    {
+        var (hostClient, _, hostId, _, menuId, dinnerId) = await SeedHostMenuAndDinnerAsync();
+        await ReserveAsync(guestClient, dinnerId);
+        await StartAndEndDinnerAsync(hostClient, hostId, dinnerId);
+        return (menuId, dinnerId);
+    }
+
+    private static async Task<HttpResponseMessage> ReserveAsync(HttpClient guestClient, string dinnerId)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, $"reservations{ApiVersion}")
+        {
+            Content = JsonBody(new { dinnerId, guestCount = 1 }),
+        };
+        req.Headers.TryAddWithoutValidation("Idempotency-Key", Guid.NewGuid().ToString());
+        var resp = await guestClient.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+        return resp;
+    }
+
+    private static async Task StartAndEndDinnerAsync(HttpClient hostClient, string hostId, string dinnerId)
+    {
+        (await hostClient.PostAsync(
+            $"hosts/{hostId}/dinners/{dinnerId}/start{ApiVersion}",
+            new StringContent("", Encoding.UTF8, "application/json"))).EnsureSuccessStatusCode();
+        (await hostClient.PostAsync(
+            $"hosts/{hostId}/dinners/{dinnerId}/end{ApiVersion}",
+            new StringContent("", Encoding.UTF8, "application/json"))).EnsureSuccessStatusCode();
+    }
 
     private async Task<(HttpClient hostClient, string hostToken, string hostId, string hostUserId, string menuId, string dinnerId)>
         SeedHostMenuAndDinnerAsync()
@@ -204,8 +309,11 @@ public class MenuReviewTests : IClassFixture<WebApplicationFactory<Program>>
 
     private sealed record TokenReply(string Token);
     private sealed record IdOnly(string Id);
+    private sealed record ReservationIdOnly(string Id);
     private sealed record ReviewBody(string Id, string MenuId, string DinnerId, string GuestUserId, int Rating, string Comment);
     private sealed record ProblemWithErrors(int Status, string? Code, Dictionary<string, string[]>? Errors);
+    private sealed record ProblemWithRules(int Status, string? Code, List<RuleEntry>? Rules);
+    private sealed record RuleEntry(string Code, string? Detail);
     private sealed record PagedEnvelope<T>(List<T> Items, PageLink? Next);
     private sealed record PageLink(string Cursor, string Href);
 }

--- a/Api/tests/2022-12-21/MenuReviewTests.cs
+++ b/Api/tests/2022-12-21/MenuReviewTests.cs
@@ -1,0 +1,211 @@
+namespace BuberDinner.Api.Tests._2022_12_21;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit.Priority;
+
+[TestCaseOrderer(PriorityOrderer.Name, PriorityOrderer.Assembly)]
+public class MenuReviewTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private const string ApiVersion = "?api-version=2022-10-01";
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public MenuReviewTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact, Priority(6)]
+    public async Task SubmitReview_returns_201_with_etag_and_location()
+    {
+        var (_, _, _, _, menuId, dinnerId) = await SeedHostMenuAndDinnerAsync();
+        var guest = await NewGuestClientAsync();
+
+        var response = await PostReviewAsync(guest.client, menuId, dinnerId, rating: 4, comment: "Great brunch!");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.ETag.Should().NotBeNull();
+        response.Headers.Location!.OriginalString.Should().StartWith("/menu-reviews/");
+        var body = await response.Content.ReadAsAsync<ReviewBody>();
+        body!.Rating.Should().Be(4);
+        body.Comment.Should().Be("Great brunch!");
+        body.GuestUserId.Should().Be(guest.userId);
+    }
+
+    [Fact, Priority(6)]
+    public async Task SubmitReview_with_rating_out_of_range_returns_422_via_FluentValidation()
+    {
+        var (_, _, _, _, menuId, dinnerId) = await SeedHostMenuAndDinnerAsync();
+        var guest = await NewGuestClientAsync();
+
+        var response = await PostReviewAsync(guest.client, menuId, dinnerId, rating: 99, comment: "x");
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        var problem = await response.Content.ReadAsAsync<ProblemWithErrors>();
+        problem!.Code.Should().Be("invalid-input");
+        problem.Errors.Should().ContainKey("Rating",
+            "FluentValidation surfaces field-bound failures through the standard 422 problem-details shape");
+        problem.Errors!["Rating"].Should().Contain(e => e.Contains("between 1 and 5"));
+    }
+
+    [Fact, Priority(6)]
+    public async Task SubmitReview_with_empty_comment_returns_422_via_FluentValidation()
+    {
+        var (_, _, _, _, menuId, dinnerId) = await SeedHostMenuAndDinnerAsync();
+        var guest = await NewGuestClientAsync();
+
+        var response = await PostReviewAsync(guest.client, menuId, dinnerId, rating: 3, comment: "");
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        var problem = await response.Content.ReadAsAsync<ProblemWithErrors>();
+        problem!.Errors.Should().ContainKey("Comment");
+    }
+
+    [Fact, Priority(6)]
+    public async Task SubmitReview_against_missing_menu_returns_404_per_Recipe_22_fail_loud()
+    {
+        var (_, _, _, _, _, dinnerId) = await SeedHostMenuAndDinnerAsync();
+        var guest = await NewGuestClientAsync();
+        var phantomMenuId = Guid.NewGuid().ToString();
+
+        var req = new HttpRequestMessage(HttpMethod.Post, $"menu-reviews{ApiVersion}")
+        {
+            Content = JsonBody(new { menuId = phantomMenuId, dinnerId, rating = 3, comment = "ok" }),
+        };
+        var response = await guest.client.SendAsync(req);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact, Priority(6)]
+    public async Task UpdateReview_with_invalid_rating_returns_422_via_FluentValidation_before_handler_runs()
+    {
+        var (_, _, _, _, menuId, dinnerId) = await SeedHostMenuAndDinnerAsync();
+        var guest = await NewGuestClientAsync();
+        var first = await PostReviewAsync(guest.client, menuId, dinnerId, rating: 3, comment: "okay");
+        var id = (await first.Content.ReadAsAsync<ReviewBody>())!.Id;
+
+        var response = await guest.client.PutAsync($"menu-reviews/{id}{ApiVersion}",
+            JsonBody(new { rating = 0, comment = "rolled-back" }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        var problem = await response.Content.ReadAsAsync<ProblemWithErrors>();
+        problem!.Errors.Should().ContainKey("Rating");
+    }
+
+    [Fact, Priority(6)]
+    public async Task UpdateReview_as_different_guest_returns_404_NotFound_leak_shield()
+    {
+        var (_, _, _, _, menuId, dinnerId) = await SeedHostMenuAndDinnerAsync();
+        var owner = await NewGuestClientAsync();
+        var first = await PostReviewAsync(owner.client, menuId, dinnerId, rating: 4, comment: "ok");
+        var id = (await first.Content.ReadAsAsync<ReviewBody>())!.Id;
+
+        var intruder = await NewGuestClientAsync();
+        var response = await intruder.client.PutAsync($"menu-reviews/{id}{ApiVersion}",
+            JsonBody(new { rating = 1, comment = "vandalism" }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact, Priority(6)]
+    public async Task ListReviewsForMenu_paginates()
+    {
+        var (_, _, _, _, menuId, dinnerId) = await SeedHostMenuAndDinnerAsync();
+        var guest = await NewGuestClientAsync();
+        for (int i = 0; i < 7; i++)
+            (await PostReviewAsync(guest.client, menuId, dinnerId, rating: 5, comment: $"Review {i}"))
+                .EnsureSuccessStatusCode();
+
+        var url = $"menu-reviews/for-menu/{menuId}{ApiVersion}&limit=3";
+        var p1 = await (await guest.client.GetAsync(url)).Content.ReadAsAsync<PagedEnvelope<ReviewBody>>();
+        p1!.Items.Count.Should().Be(3);
+        p1.Next.Should().NotBeNull();
+
+        var p2 = await (await guest.client.GetAsync($"{url}&cursor={Uri.EscapeDataString(p1.Next!.Cursor)}"))
+            .Content.ReadAsAsync<PagedEnvelope<ReviewBody>>();
+        p2!.Items.Count.Should().Be(3);
+
+        var p3 = await (await guest.client.GetAsync($"{url}&cursor={Uri.EscapeDataString(p2.Next!.Cursor)}"))
+            .Content.ReadAsAsync<PagedEnvelope<ReviewBody>>();
+        p3!.Items.Count.Should().Be(1);
+        p3.Next.Should().BeNull();
+    }
+
+    // ---------------- helpers ----------------
+
+    private async Task<(HttpClient hostClient, string hostToken, string hostId, string hostUserId, string menuId, string dinnerId)>
+        SeedHostMenuAndDinnerAsync()
+    {
+        var client = _factory.CreateClient();
+        var userId = $"h_{Guid.NewGuid():N}".Substring(0, 14);
+        var token = await RegisterAsync(client, userId);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var hostResp = await client.PostAsync($"hosts{ApiVersion}", JsonBody(new { displayName = "PR5" }));
+        var hostId = (await hostResp.Content.ReadAsAsync<IdOnly>())!.Id;
+
+        var menuResp = await client.PostAsync($"hosts/{hostId}/menus/create{ApiVersion}", JsonBody(new
+        {
+            name = "M",
+            description = "d",
+            sections = new[] { new { name = "s", description = "d", items = new[] { new { name = "i", description = "d" } } } },
+        }));
+        var menuId = (await menuResp.Content.ReadAsAsync<IdOnly>())!.Id;
+
+        var dinnerResp = await client.PostAsync($"hosts/{hostId}/dinners{ApiVersion}", JsonBody(new
+        {
+            name = "Dinner",
+            description = "d",
+            menuId,
+            startDateTime = "2026-07-01T18:00:00Z",
+            endDateTime = "2026-07-01T21:00:00Z",
+        }));
+        var dinnerId = (await dinnerResp.Content.ReadAsAsync<IdOnly>())!.Id;
+
+        return (client, token, hostId, userId, menuId, dinnerId);
+    }
+
+    private async Task<(HttpClient client, string userId, string token)> NewGuestClientAsync()
+    {
+        var client = _factory.CreateClient();
+        var userId = $"g_{Guid.NewGuid():N}".Substring(0, 14);
+        var token = await RegisterAsync(client, userId);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return (client, userId, token);
+    }
+
+    private static async Task<string> RegisterAsync(HttpClient client, string userId)
+    {
+        var body = $$"""
+            { "userId":"{{userId}}", "firstName":"F", "lastName":"L",
+              "email":"{{userId}}@example.com", "password":"SecretP5$$word" }
+            """;
+        var resp = await client.PostAsync("authentication/register",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadAsAsync<TokenReply>())!.Token;
+    }
+
+    private static Task<HttpResponseMessage> PostReviewAsync(
+        HttpClient client, string menuId, string dinnerId, int rating, string comment) =>
+        client.PostAsync($"menu-reviews{ApiVersion}", JsonBody(new { menuId, dinnerId, rating, comment }));
+
+    private static StringContent JsonBody(object payload) =>
+        new(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+    private sealed record TokenReply(string Token);
+    private sealed record IdOnly(string Id);
+    private sealed record ReviewBody(string Id, string MenuId, string DinnerId, string GuestUserId, int Rating, string Comment);
+    private sealed record ProblemWithErrors(int Status, string? Code, Dictionary<string, string[]>? Errors);
+    private sealed record PagedEnvelope<T>(List<T> Items, PageLink? Next);
+    private sealed record PageLink(string Cursor, string Href);
+}

--- a/Api/tests/BuberDinner.Api.Tests.csproj
+++ b/Api/tests/BuberDinner.Api.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
    <ItemGroup>
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+      <PackageReference Include="Trellis.Testing" />
       <PackageReference Include="Xunit.Priority" />
    </ItemGroup>
    <ItemGroup>

--- a/Application/src/Abstractions/Persistence/IMenuReviewRepository.cs
+++ b/Application/src/Abstractions/Persistence/IMenuReviewRepository.cs
@@ -1,0 +1,10 @@
+namespace BuberDinner.Application.Abstractions.Persistence;
+
+using System.Collections.Generic;
+using BuberDinner.Domain.Menu.ValueObject;
+using BuberDinner.Domain.MenuReview.Entities;
+
+public interface IMenuReviewRepository : IRepository<MenuReview>
+{
+    IReadOnlyList<MenuReview> GetPageForMenu(MenuId menuId, Trellis.PageSize pageSize, System.Guid? afterId);
+}

--- a/Application/src/Abstractions/Persistence/IReservationRepository.cs
+++ b/Application/src/Abstractions/Persistence/IReservationRepository.cs
@@ -1,6 +1,8 @@
 namespace BuberDinner.Application.Abstractions.Persistence;
 
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using BuberDinner.Domain.Dinner.ValueObject;
 using BuberDinner.Domain.Reservation.Entities;
 using BuberDinner.Domain.User.ValueObjects;
@@ -10,4 +12,6 @@ public interface IReservationRepository : IRepository<Reservation>
     IReadOnlyList<Reservation> GetPageForDinner(DinnerId dinnerId, Trellis.PageSize pageSize, System.Guid? afterId);
 
     IReadOnlyList<Reservation> GetPageForGuest(UserId guestUserId, Trellis.PageSize pageSize, System.Guid? afterId);
+
+    ValueTask<Reservation?> FindByDinnerAndGuest(DinnerId dinnerId, UserId guestUserId, CancellationToken cancellationToken);
 }

--- a/Application/src/BuberDinner.Application.csproj
+++ b/Application/src/BuberDinner.Application.csproj
@@ -8,6 +8,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Trellis.Mediator" />
+    <PackageReference Include="Trellis.Mediator.FluentValidation" />
     <PackageReference Include="Trellis.Http.Abstractions" />
   </ItemGroup>
 

--- a/Application/src/MenuReviews/Commands/SubmitMenuReviewCommand.cs
+++ b/Application/src/MenuReviews/Commands/SubmitMenuReviewCommand.cs
@@ -1,0 +1,25 @@
+namespace BuberDinner.Application.MenuReviews.Commands;
+
+using BuberDinner.Domain.Dinner.ValueObject;
+using BuberDinner.Domain.Menu.ValueObject;
+using BuberDinner.Domain.MenuReview.Entities;
+using BuberDinner.Domain.User.ValueObjects;
+using Mediator;
+
+public sealed class SubmitMenuReviewCommand : ICommand<Result<MenuReview>>
+{
+    public MenuId MenuId { get; }
+    public DinnerId DinnerId { get; }
+    public UserId GuestUserId { get; }
+    public int Rating { get; }
+    public string Comment { get; }
+
+    public SubmitMenuReviewCommand(MenuId menuId, DinnerId dinnerId, UserId guestUserId, int rating, string comment)
+    {
+        MenuId = menuId;
+        DinnerId = dinnerId;
+        GuestUserId = guestUserId;
+        Rating = rating;
+        Comment = comment;
+    }
+}

--- a/Application/src/MenuReviews/Commands/SubmitMenuReviewCommandHandler.cs
+++ b/Application/src/MenuReviews/Commands/SubmitMenuReviewCommandHandler.cs
@@ -1,0 +1,40 @@
+namespace BuberDinner.Application.MenuReviews.Commands;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.Menu;
+using BuberDinner.Domain.Menu.ValueObject;
+using BuberDinner.Domain.MenuReview.Entities;
+using Mediator;
+
+public sealed class SubmitMenuReviewCommandHandler
+    : ICommandHandler<SubmitMenuReviewCommand, Result<MenuReview>>
+{
+    private readonly IMenuReviewRepository _reviewRepository;
+    private readonly IRepository<Menu> _menuRepository;
+    private readonly TimeProvider _clock;
+
+    public SubmitMenuReviewCommandHandler(
+        IMenuReviewRepository reviewRepository,
+        IRepository<Menu> menuRepository,
+        TimeProvider clock)
+    {
+        _reviewRepository = reviewRepository;
+        _menuRepository = menuRepository;
+        _clock = clock;
+    }
+
+    public async ValueTask<Result<MenuReview>> Handle(
+        SubmitMenuReviewCommand request, CancellationToken cancellationToken) =>
+        await LoadMenuAsync(request.MenuId, cancellationToken)
+            .BindAsync(_ => MenuReview.TryCreate(
+                request.MenuId, request.DinnerId, request.GuestUserId,
+                request.Rating, request.Comment, _clock))
+            .TapAsync(review => _reviewRepository.Add(review, cancellationToken));
+
+    private async ValueTask<Result<Menu>> LoadMenuAsync(MenuId menuId, CancellationToken cancellationToken) =>
+        (await _menuRepository.FindById(menuId.Value.ToString(), cancellationToken))
+            .ToResult(new Error.NotFound(ResourceRef.For<Menu>(menuId)));
+}

--- a/Application/src/MenuReviews/Commands/SubmitMenuReviewCommandHandler.cs
+++ b/Application/src/MenuReviews/Commands/SubmitMenuReviewCommandHandler.cs
@@ -4,9 +4,13 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.Dinner.Entities;
+using BuberDinner.Domain.Dinner.ValueObject;
 using BuberDinner.Domain.Menu;
 using BuberDinner.Domain.Menu.ValueObject;
 using BuberDinner.Domain.MenuReview.Entities;
+using BuberDinner.Domain.Reservation.ValueObject;
+using BuberDinner.Domain.User.ValueObjects;
 using Mediator;
 
 public sealed class SubmitMenuReviewCommandHandler
@@ -14,21 +18,39 @@ public sealed class SubmitMenuReviewCommandHandler
 {
     private readonly IMenuReviewRepository _reviewRepository;
     private readonly IRepository<Menu> _menuRepository;
+    private readonly IRepository<Dinner> _dinnerRepository;
+    private readonly IReservationRepository _reservationRepository;
     private readonly TimeProvider _clock;
 
     public SubmitMenuReviewCommandHandler(
         IMenuReviewRepository reviewRepository,
         IRepository<Menu> menuRepository,
+        IRepository<Dinner> dinnerRepository,
+        IReservationRepository reservationRepository,
         TimeProvider clock)
     {
         _reviewRepository = reviewRepository;
         _menuRepository = menuRepository;
+        _dinnerRepository = dinnerRepository;
+        _reservationRepository = reservationRepository;
         _clock = clock;
     }
 
     public async ValueTask<Result<MenuReview>> Handle(
         SubmitMenuReviewCommand request, CancellationToken cancellationToken) =>
         await LoadMenuAsync(request.MenuId, cancellationToken)
+            .BindAsync(_ => LoadDinnerAsync(request.DinnerId, cancellationToken))
+            .EnsureAsync(
+                d => d.MenuId == request.MenuId,
+                new Error.NotFound(ResourceRef.For<Dinner>(request.DinnerId))
+                {
+                    Detail = "Dinner is not associated with the specified menu.",
+                })
+            .BindAsync(d => EnsureCallerReservedAsync(d, request.GuestUserId, cancellationToken))
+            .EnsureAsync(
+                d => d.Status == DinnerStatus.Ended,
+                d => Error.InvalidInput.ForRule("review.dinner-not-ended",
+                    $"Cannot review a dinner whose status is {d.Status.Value}. Only Ended dinners can be reviewed."))
             .BindAsync(_ => MenuReview.TryCreate(
                 request.MenuId, request.DinnerId, request.GuestUserId,
                 request.Rating, request.Comment, _clock))
@@ -37,4 +59,20 @@ public sealed class SubmitMenuReviewCommandHandler
     private async ValueTask<Result<Menu>> LoadMenuAsync(MenuId menuId, CancellationToken cancellationToken) =>
         (await _menuRepository.FindById(menuId.Value.ToString(), cancellationToken))
             .ToResult(new Error.NotFound(ResourceRef.For<Menu>(menuId)));
+
+    private async ValueTask<Result<Dinner>> LoadDinnerAsync(DinnerId dinnerId, CancellationToken cancellationToken) =>
+        (await _dinnerRepository.FindById(dinnerId.Value.ToString(), cancellationToken))
+            .ToResult(new Error.NotFound(ResourceRef.For<Dinner>(dinnerId)));
+
+    private async ValueTask<Result<Dinner>> EnsureCallerReservedAsync(
+        Dinner dinner, UserId guestUserId, CancellationToken cancellationToken)
+    {
+        var reservation = await _reservationRepository.FindByDinnerAndGuest(dinner.Id, guestUserId, cancellationToken);
+        if (reservation is null || reservation.Status != ReservationStatus.Reserved)
+            return Result.Fail<Dinner>(new Error.NotFound(ResourceRef.For<Dinner>(dinner.Id))
+            {
+                Detail = "Caller did not reserve this dinner.",
+            });
+        return Result.Ok(dinner);
+    }
 }

--- a/Application/src/MenuReviews/Commands/UpdateMenuReviewCommand.cs
+++ b/Application/src/MenuReviews/Commands/UpdateMenuReviewCommand.cs
@@ -1,0 +1,56 @@
+namespace BuberDinner.Application.MenuReviews.Commands;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.MenuReview.Entities;
+using BuberDinner.Domain.MenuReview.ValueObject;
+using BuberDinner.Domain.User.ValueObjects;
+using Mediator;
+
+public sealed class UpdateMenuReviewCommand : ICommand<Result<MenuReview>>
+{
+    public MenuReviewId ReviewId { get; }
+    public UserId CallerGuestUserId { get; }
+    public int Rating { get; }
+    public string Comment { get; }
+
+    public UpdateMenuReviewCommand(MenuReviewId reviewId, UserId callerGuestUserId, int rating, string comment)
+    {
+        ReviewId = reviewId;
+        CallerGuestUserId = callerGuestUserId;
+        Rating = rating;
+        Comment = comment;
+    }
+}
+
+public sealed class UpdateMenuReviewCommandHandler
+    : ICommandHandler<UpdateMenuReviewCommand, Result<MenuReview>>
+{
+    private readonly IMenuReviewRepository _repo;
+    private readonly TimeProvider _clock;
+
+    public UpdateMenuReviewCommandHandler(IMenuReviewRepository repo, TimeProvider clock)
+    {
+        _repo = repo;
+        _clock = clock;
+    }
+
+    public async ValueTask<Result<MenuReview>> Handle(
+        UpdateMenuReviewCommand request, CancellationToken cancellationToken) =>
+        await LoadReviewOwnedByAsync(request.ReviewId, request.CallerGuestUserId, cancellationToken)
+            .BindAsync(review => review.UpdateContent(request.Rating, request.Comment, _clock))
+            .TapAsync(review => _repo.Update(review, cancellationToken));
+
+    private async ValueTask<Result<MenuReview>> LoadReviewOwnedByAsync(
+        MenuReviewId reviewId, UserId callerGuestUserId, CancellationToken cancellationToken) =>
+        (await _repo.FindById(reviewId.Value.ToString(), cancellationToken))
+            .ToResult(new Error.NotFound(ResourceRef.For<MenuReview>(reviewId)))
+            .Ensure(
+                r => r.GuestUserId == callerGuestUserId,
+                new Error.NotFound(ResourceRef.For<MenuReview>(reviewId))
+                {
+                    Detail = "Review does not belong to the calling guest.",
+                });
+}

--- a/Application/src/MenuReviews/Events/MenuReviewEventHandlers.cs
+++ b/Application/src/MenuReviews/Events/MenuReviewEventHandlers.cs
@@ -1,0 +1,44 @@
+namespace BuberDinner.Application.MenuReviews.Events;
+
+using System.Threading;
+using System.Threading.Tasks;
+using BuberDinner.Domain.MenuReview.Events;
+using Microsoft.Extensions.Logging;
+using Trellis.Mediator;
+
+public sealed class LogMenuReviewSubmittedHandler : IDomainEventHandler<MenuReviewSubmitted>
+{
+    private readonly ILogger<LogMenuReviewSubmittedHandler> _logger;
+
+    public LogMenuReviewSubmittedHandler(ILogger<LogMenuReviewSubmittedHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public ValueTask HandleAsync(MenuReviewSubmitted notification, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Review {ReviewId} submitted by guest {GuestUserId} for menu {MenuId}: {Rating}/5 at {OccurredAt:o}",
+            notification.ReviewId.Value, notification.GuestUserId.Value,
+            notification.MenuId.Value, notification.Rating, notification.OccurredAt);
+        return ValueTask.CompletedTask;
+    }
+}
+
+public sealed class LogMenuReviewUpdatedHandler : IDomainEventHandler<MenuReviewUpdated>
+{
+    private readonly ILogger<LogMenuReviewUpdatedHandler> _logger;
+
+    public LogMenuReviewUpdatedHandler(ILogger<LogMenuReviewUpdatedHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public ValueTask HandleAsync(MenuReviewUpdated notification, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Review {ReviewId} updated to {NewRating}/5 at {OccurredAt:o}",
+            notification.ReviewId.Value, notification.NewRating, notification.OccurredAt);
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Application/src/MenuReviews/Queries/GetMenuReviewQuery.cs
+++ b/Application/src/MenuReviews/Queries/GetMenuReviewQuery.cs
@@ -1,0 +1,28 @@
+namespace BuberDinner.Application.MenuReviews.Queries;
+
+using System.Threading;
+using System.Threading.Tasks;
+using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.MenuReview.Entities;
+using BuberDinner.Domain.MenuReview.ValueObject;
+using Mediator;
+
+public sealed class GetMenuReviewQuery : IRequest<Result<MenuReview>>
+{
+    public MenuReviewId ReviewId { get; }
+    public GetMenuReviewQuery(MenuReviewId reviewId) => ReviewId = reviewId;
+}
+
+public sealed class GetMenuReviewQueryHandler : IRequestHandler<GetMenuReviewQuery, Result<MenuReview>>
+{
+    private readonly IMenuReviewRepository _repo;
+
+    public GetMenuReviewQueryHandler(IMenuReviewRepository repo)
+    {
+        _repo = repo;
+    }
+
+    public async ValueTask<Result<MenuReview>> Handle(GetMenuReviewQuery request, CancellationToken cancellationToken) =>
+        (await _repo.FindById(request.ReviewId.Value.ToString(), cancellationToken))
+            .ToResult(new Error.NotFound(ResourceRef.For<MenuReview>(request.ReviewId)));
+}

--- a/Application/src/MenuReviews/Queries/ListReviewsForMenuQuery.cs
+++ b/Application/src/MenuReviews/Queries/ListReviewsForMenuQuery.cs
@@ -1,0 +1,52 @@
+namespace BuberDinner.Application.MenuReviews.Queries;
+
+using System.Threading;
+using System.Threading.Tasks;
+using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.Menu.ValueObject;
+using BuberDinner.Domain.MenuReview.Entities;
+using Mediator;
+
+public sealed class ListReviewsForMenuQuery : IRequest<Result<Page<MenuReview>>>
+{
+    public MenuId MenuId { get; }
+    public Cursor? Cursor { get; }
+    public int? Limit { get; }
+
+    public ListReviewsForMenuQuery(MenuId menuId, Cursor? cursor = null, int? limit = null)
+    {
+        MenuId = menuId;
+        Cursor = cursor;
+        Limit = limit;
+    }
+}
+
+public sealed class ListReviewsForMenuQueryHandler
+    : IRequestHandler<ListReviewsForMenuQuery, Result<Page<MenuReview>>>
+{
+    private readonly IMenuReviewRepository _repo;
+
+    public ListReviewsForMenuQueryHandler(IMenuReviewRepository repo)
+    {
+        _repo = repo;
+    }
+
+    public ValueTask<Result<Page<MenuReview>>> Handle(
+        ListReviewsForMenuQuery request, CancellationToken cancellationToken)
+    {
+        var pageSize = PageSize.FromRequested(request.Limit);
+
+        System.Guid? afterId = null;
+        if (request.Cursor is { } cursor)
+        {
+            var decoded = CursorCodec.TryDecode<System.Guid>(cursor, fieldName: "cursor");
+            if (!decoded.TryGetValue(out var id, out var cursorError))
+                return ValueTask.FromResult(Result.Fail<Page<MenuReview>>(cursorError));
+            afterId = id;
+        }
+
+        var overFetched = _repo.GetPageForMenu(request.MenuId, pageSize, afterId);
+        var page = PageBuilder.FromOverFetch(overFetched, pageSize, r => r.Id.Value);
+        return ValueTask.FromResult(Result.Ok(page));
+    }
+}

--- a/Application/src/MenuReviews/Validators/MenuReviewValidators.cs
+++ b/Application/src/MenuReviews/Validators/MenuReviewValidators.cs
@@ -1,0 +1,42 @@
+namespace BuberDinner.Application.MenuReviews.Validators;
+
+using BuberDinner.Application.MenuReviews.Commands;
+using FluentValidation;
+
+/// <summary>
+/// Validates <see cref="SubmitMenuReviewCommand"/> at the Trellis Mediator
+/// <c>ValidationBehavior</c> stage — runs BEFORE the handler, short-circuits to
+/// 422 Problem Details on failure with one field violation per offending property.
+/// Wired by <c>services.AddTrellisFluentValidation(typeof(SubmitMenuReviewCommandValidator).Assembly)</c>.
+/// </summary>
+public sealed class SubmitMenuReviewCommandValidator : AbstractValidator<SubmitMenuReviewCommand>
+{
+    public SubmitMenuReviewCommandValidator()
+    {
+        RuleFor(x => x.Rating)
+            .InclusiveBetween(1, 5)
+            .WithMessage("Rating must be between 1 and 5.");
+
+        RuleFor(x => x.Comment)
+            .NotEmpty()
+            .WithMessage("Comment is required.")
+            .MaximumLength(1000)
+            .WithMessage("Comment must not exceed 1000 characters.");
+    }
+}
+
+public sealed class UpdateMenuReviewCommandValidator : AbstractValidator<UpdateMenuReviewCommand>
+{
+    public UpdateMenuReviewCommandValidator()
+    {
+        RuleFor(x => x.Rating)
+            .InclusiveBetween(1, 5)
+            .WithMessage("Rating must be between 1 and 5.");
+
+        RuleFor(x => x.Comment)
+            .NotEmpty()
+            .WithMessage("Comment is required.")
+            .MaximumLength(1000)
+            .WithMessage("Comment must not exceed 1000 characters.");
+    }
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,14 +30,17 @@
     <PackageVersion Include="Trellis.Mediator" Version="$(TrellisVersion)" />
     <PackageVersion Include="Trellis.Primitives" Version="$(TrellisVersion)" />
     <PackageVersion Include="Trellis.StateMachine" Version="$(TrellisVersion)" />
+    <PackageVersion Include="Trellis.Mediator.FluentValidation" Version="$(TrellisVersion)" />
+    <PackageVersion Include="Trellis.ServiceDefaults" Version="$(TrellisVersion)" />
     <PackageVersion Include="Stateless" Version="5.20.1" />
   </ItemGroup>
   <!-- Test -->
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="FluentAssertions" Version="7.2.2" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="Trellis.Testing" Version="$(TrellisVersion)" />
     <PackageVersion Include="xunit" Version="2.8.0" />
     <PackageVersion Include="Xunit.DependencyInjection" Version="9.3.0" />
     <PackageVersion Include="Xunit.Priority" Version="1.1.6" />

--- a/Docs/DomainModels/Aggregates.MenuReview.md
+++ b/Docs/DomainModels/Aggregates.MenuReview.md
@@ -19,19 +19,31 @@ Only the owning guest can update. Reviews are not deleted.
 
 ### Validation
 
-Validation lives in three places:
+Validation lives in four places, each with a distinct job:
 
-1. **Domain invariants** — `MenuReview.s_validator` enforces rating ∈ [1, 5],
-   non-empty comment ≤ 1000 chars, non-empty IDs. The aggregate refuses to
-   exist in an invalid state.
-2. **Command boundary** (PR 5 showcase) — `SubmitMenuReviewCommandValidator`
-   and `UpdateMenuReviewCommandValidator` re-state those rules as FluentValidation
-   rules wired into the Mediator pipeline via `AddTrellisFluentValidation(...)`.
-   These run BEFORE the handler and surface field-bound 422s with the standard
-   Trellis Problem Details shape.
-3. **Wire DTO** — `SubmitMenuReviewRequest.ToSubmitMenuReviewCommand(UserId)`
-   does the primitive → `MenuId`/`DinnerId` value-object parse via the
-   `TryCreate`/`Combine`/`Map` Result pipeline.
+1. **Content invariants (domain)** — `MenuReview.s_inputValidator` is a private
+   `InlineValidator<ContentInputs>` that runs over a `(rating, comment)` record
+   BEFORE any mutation. It enforces rating ∈ [1, 5], non-empty comment ≤ 1000
+   chars. Failures aggregate into one `Error.InvalidInput`.
+2. **FK integrity (wire)** — `SubmitMenuReviewRequest.ToSubmitMenuReviewCommand(UserId)`
+   parses the inbound primitive `menuId`/`dinnerId` strings into `MenuId`/`DinnerId`
+   value objects via the `TryCreate`/`Combine`/`Map` Result pipeline — a malformed
+   GUID produces a 422 before the handler runs.
+3. **Cross-aggregate gates (handler)** — `SubmitMenuReviewCommandHandler` chains the
+   following ROP gates so an orphan/unauthorised review can't be created:
+   1. Menu exists → 404.
+   2. Dinner exists → 404.
+   3. Dinner.MenuId == request.MenuId → 404 (leak-shielded).
+   4. Caller has a non-cancelled reservation for the dinner → 404 (leak-shielded —
+      identical shape to the missing-dinner case to avoid revealing dinner existence
+      to non-attendees).
+   5. Dinner.Status == `Ended` → 422 `review.dinner-not-ended` (status revealed
+      only AFTER the caller is proven to be an attendee).
+4. **Command boundary (PR 5 showcase)** — `SubmitMenuReviewCommandValidator` and
+   `UpdateMenuReviewCommandValidator` re-state the rating/comment rules as
+   FluentValidation rules wired into the Mediator pipeline via
+   `AddTrellisFluentValidation(...)`. These run BEFORE the handler and surface
+   field-bound 422s with the standard Trellis Problem Details shape.
 
 ### Wire shape
 

--- a/Docs/DomainModels/Aggregates.MenuReview.md
+++ b/Docs/DomainModels/Aggregates.MenuReview.md
@@ -1,24 +1,57 @@
-# Domain Aggregates
+# Menu Review aggregate
 
-## Menu Review
+A guest who attended a dinner can leave a rating + comment on the menu they
+experienced. Owned by both the guest (`GuestUserId`) and the menu (`MenuId`),
+with the dinner they attended captured as a foreign key (`DinnerId`).
 
-```csharp
-class MenuReview
-{
-    // TODO: Add methods
-}
-```
+### Status
+
+No state machine — reviews don't transition. Two operations exist:
+`TryCreate` (initial submit) and `UpdateContent` (edit the rating + comment).
+Only the owning guest can update. Reviews are not deleted.
+
+### Domain events
+
+| Event | When |
+|---|---|
+| `MenuReviewSubmitted` | `TryCreate` succeeds |
+| `MenuReviewUpdated`   | `UpdateContent` succeeds |
+
+### Validation
+
+Validation lives in three places:
+
+1. **Domain invariants** — `MenuReview.s_validator` enforces rating ∈ [1, 5],
+   non-empty comment ≤ 1000 chars, non-empty IDs. The aggregate refuses to
+   exist in an invalid state.
+2. **Command boundary** (PR 5 showcase) — `SubmitMenuReviewCommandValidator`
+   and `UpdateMenuReviewCommandValidator` re-state those rules as FluentValidation
+   rules wired into the Mediator pipeline via `AddTrellisFluentValidation(...)`.
+   These run BEFORE the handler and surface field-bound 422s with the standard
+   Trellis Problem Details shape.
+3. **Wire DTO** — `SubmitMenuReviewRequest.ToSubmitMenuReviewCommand(UserId)`
+   does the primitive → `MenuId`/`DinnerId` value-object parse via the
+   `TryCreate`/`Combine`/`Map` Result pipeline.
+
+### Wire shape
 
 ```json
 {
-    "id": { "value": "00000000-0000-0000-0000-000000000000" },
+    "id": "019e98be-8ad3-7d2c-9daf-4c0e5d018ba9",
+    "menuId": "019e98be-8934-72c5-83e4-8a0052d4c70b",
+    "dinnerId": "019e98be-89c2-7601-80c9-438d26589e35",
+    "guestUserId": "guest_551d1b36",
     "rating": 4,
-    "comment": "A menu with yummy food",
-    "hostId": { "value": "00000000-0000-0000-0000-000000000000" },
-    "menuId": { "value": "00000000-0000-0000-0000-000000000000" },
-    "guestId": { "value": "00000000-0000-0000-0000-000000000000" },
-    "dinnerId": { "value": "00000000-0000-0000-0000-000000000000" },
-    "createdDateTime": "2020-01-01T00:00:00.0000000Z",
-    "updatedDateTime": "2020-01-01T00:00:00.0000000Z"
+    "comment": "Loved the brunch — three-egg omelette was perfect."
 }
 ```
+
+### Deferred to future PRs
+
+- **Aggregate audit timestamps** — `Aggregate<TId>` ships `CreatedAt`/`LastModified`
+  populated by `Trellis.EntityFrameworkCore` at row-write time. For the in-memory
+  showcase they remain `default(DateTimeOffset)`. EF persistence is its own future PR.
+- **Resource-based authorization for updates** — currently the owning-guest check
+  lives in `UpdateMenuReviewCommandHandler.LoadReviewOwnedByAsync`. A future
+  `SharedResourceLoaderById<MenuReview, MenuReviewId>` would let it use
+  `IAuthorizeResource<MenuReview>` declaratively on the command.

--- a/Docs/PR5_REVIEWS_FLUENTVALIDATION_TESTING_DEFAULTS.md
+++ b/Docs/PR5_REVIEWS_FLUENTVALIDATION_TESTING_DEFAULTS.md
@@ -1,0 +1,159 @@
+# PR 5 — Reviews + FluentValidation + Trellis.Testing + Trellis.ServiceDefaults
+
+> *Capstone of the 5-PR showcase arc. Adds the final aggregate (`MenuReview`), bundles
+> three previously-unwired Trellis features (`AddTrellisFluentValidation`,
+> `Trellis.Testing` matchers, `Trellis.ServiceDefaults` composition builder), and
+> demonstrates how a real composition root collapses from a dozen `Add*` calls into one
+> fluent `AddTrellis(t => t.Use*(...)...)` expression.*
+
+---
+
+## What this PR adds (at a glance)
+
+| Capability | Where | Cookbook |
+|---|---|---|
+| `MenuReview` aggregate (`Submit`, `UpdateContent`) | `Domain/src/MenuReview/Entities/MenuReview.cs` | Recipe 1 |
+| 2 domain events (`MenuReviewSubmitted`, `MenuReviewUpdated`) | `Domain/src/MenuReview/Events/` | Recipe 17 |
+| `POST /menu-reviews` / `PUT /menu-reviews/{id}` / `GET /menu-reviews/{id}` / `GET /menu-reviews/for-menu/{menuId}` | `MenuReviewsController` | Recipes 3 + 22 |
+| **FluentValidation at the command boundary** via `IValidator<TCommand>` + auto-wired Mediator behavior | `SubmitMenuReviewCommandValidator`, `UpdateMenuReviewCommandValidator` | Mediator §validation |
+| **`Trellis.Testing` matchers** (`.Should().BeSuccess()`, `.BeFailureOfType<>()`, `.Unwrap()`) | `Domain/tests/MenuReviewTests.cs` | trellis-api-testing.md |
+| **`Trellis.ServiceDefaults` composition builder** — `services.AddTrellis(t => t.Use*(...)...)` replaces 10+ individual `Add*` calls | `Api/src/DependencyInjection.cs` | trellis-api-servicedefaults.md |
+| Stub cleanup: orphan `MenuReviewId` in the wrong namespace | `Domain/src/Menu/Menu.cs`, `Infrastructure/src/Persistence/Dto/MenuDto.cs`, `Infrastructure/tests/MenuRepositoryTests.cs` | — |
+
+## FluentValidation kicking in at the wire
+
+```http
+POST /menu-reviews
+{ "menuId": "...", "dinnerId": "...", "rating": 99, "comment": "x" }
+
+HTTP/1.1 422 Unprocessable Entity
+Content-Type: application/problem+json
+{
+  "status": 422, "code": "invalid-input",
+  "errors": {
+    "Rating":  ["Rating must be between 1 and 5."],
+    "Comment": ["Comment must not exceed 1000 characters."]
+  }
+}
+```
+
+The `SubmitMenuReviewCommand` and `UpdateMenuReviewCommand` types each have a
+matching `AbstractValidator<TCommand>` in `Application/MenuReviews/Validators/`.
+`services.AddTrellis(t => t.UseFluentValidation(typeof(SubmitMenuReviewCommandValidator).Assembly))`
+scans the assembly, registers every `IValidator<T>` as scoped, and plugs them into
+the existing `ValidationBehavior<,>` mediator slot. Failures aggregate into a single
+`Error.InvalidInput`, which the ASP boundary serialises as RFC 4918 Problem Details.
+
+Per-handler `AddScoped<IValidator<X>, XValidator>()` registrations are also supported
+(AOT-safe variant) — the assembly-scanning overload is just the convenient default.
+
+## The composition root before vs after
+
+**Before** (PR 4 tip — `Api/src/DependencyInjection.cs`, ~70 lines of `Add*` calls):
+```csharp
+services.AddTrellisAspWithScalarValidation();
+services.AddTrellisRouteConstraint<HostId>(nameof(HostId));
+// ... 4 more route constraints
+services.AddClaimsActorProvider(opts => opts.ActorIdClaim = "sub");
+services.AddResourceAuthorization(typeof(UpdateMenuCommand).Assembly, ...);
+services.AddDomainEventDispatch();
+services.AddDomainEventHandler<DinnerScheduled, LogDinnerScheduledHandler>();
+// ... 5 more event handlers
+services.AddTrellisIdempotency(opts => { ... });
+services.AddInMemoryIdempotencyStore();
+services.AddSingleton(TimeProvider.System);
+```
+
+**After** (PR 5 — one fluent builder):
+```csharp
+services.AddTrellis(t => t
+    .UseAsp()
+    .UseScalarValueValidation()
+    .UseProblemDetails()
+    .UseMediator()
+    .UseClaimsActorProvider(opts => opts.ActorIdClaim = "sub")
+    .UseResourceAuthorization(typeof(UpdateMenuCommand).Assembly, typeof(HostResourceLoader).Assembly)
+    .UseFluentValidation(typeof(SubmitMenuReviewCommandValidator).Assembly)
+    .UseDomainEvents()
+    .UseIdempotency(opts => { opts.Ttl = TimeSpan.FromHours(24); opts.MaxRequestBodyBytes = 256 * 1024; }));
+services.AddInMemoryIdempotencyStore();
+```
+
+The builder enforces the mutually-required call order so misconfigurations fail at
+startup, not at request time. Per-type registrations (`AddTrellisRouteConstraint<HostId>`,
+`AddDomainEventHandler<DinnerScheduled, ...>`, `AddInMemoryIdempotencyStore`) stay
+separate — those are explicitly "application-owned" per the docs.
+
+## Test-side cleanup with `Trellis.Testing` matchers
+
+**Before** (PR 2-4 domain tests):
+```csharp
+result.IsSuccess.Should().BeTrue();
+var error = result.Match(_ => null!, e => e).Should().BeOfType<Error.InvalidInput>().Subject;
+error.Rules.Items.Should().ContainSingle().Which.ReasonCode.Should().Be("...");
+```
+
+**After** (PR 5 `MenuReviewTests`):
+```csharp
+result.Should().BeSuccess();
+result.Should().BeFailureOfType<Error.InvalidInput>();
+var review = result.Unwrap();  // test-only, doesn't leak into production
+```
+
+I kept the older Dinner/Reservation tests in their existing style to avoid churn —
+just used the new matchers for the 8 new `MenuReviewTests` so future authors have a
+side-by-side reference. The framework also ships `FakeRepository<TAggregate, TId>`,
+`TestActorProvider`, and other handler-level helpers documented in
+`.github/trellis-api-testing.md`.
+
+## Domain-aggregate cleanup (drive-by)
+
+A pre-existing stub `Domain/src/MenuReview/ValueObjects/MenuId.cs` defined
+`MenuReviewId` in the **wrong** namespace (`BuberDinner.Domain.Menu.ValueObject`
+instead of `BuberDinner.Domain.MenuReview.ValueObject`). `Menu.cs` consumed it
+through that wrong namespace, papering over the bug. PR 5 deletes the stub, adds
+the canonical `MenuReviewId.cs` under the right namespace, and updates the 3
+consumers (`Menu.cs`, `MenuDto.cs`, `MenuRepositoryTests.cs`) to use the canonical
+path.
+
+## Build, test, wire-verify
+
+- **0 warnings / 0 errors**
+- **Domain 45/45** (+8 new `MenuReviewTests` using `Trellis.Testing` matchers)
+- **Application 1/1** (unchanged)
+- **Api 69/69** (+7 new `MenuReviewTests`)
+- Infrastructure 0/2 (live-Cosmos baseline, pre-existing)
+
+Wire scenarios covered by `MenuReviewTests` (and verified by curl):
+- Submit happy path → 201 + ETag + Location
+- Submit rating=99 → 422 with `errors.Rating` (FluentValidation)
+- Submit comment="" → 422 with `errors.Comment` (FluentValidation)
+- Submit both wrong → 422 with BOTH errors aggregated
+- Submit against missing menu → 404 (Recipe 22 fail-loud)
+- Update with rating=0 → 422 with `errors.Rating` (validator runs on Update too)
+- Cross-guest update → 404 (NotFound-leak-shield)
+- Paginated list → 3+3+1 of 7 items, last page `next=null`
+
+## Commit walkthrough (6 commits)
+
+| # | Scope |
+|---|---|
+| 1 | `chore(deps)`: Trellis.Mediator.FluentValidation + Trellis.Testing + Trellis.ServiceDefaults; FluentAssertions bumped to 7.2.2 (Trellis.Testing requirement) |
+| 2 | `feat(domain)`: MenuReview aggregate + 2 events + 8 tests; orphan-stub cleanup |
+| 3 | `feat(infra+app)`: MenuReviewInMemoryRepository + 4 commands/queries + 2 validators + 2 log handlers |
+| 4 | `feat(api)`: MenuReviewsController + DTOs |
+| 5 | `refactor(api)`: ServiceDefaults composition builder collapses ~30 lines of Add* into one fluent expression |
+| 6 | `test(api) + docs`: 7 integration tests + 4 .http files + Aggregates.MenuReview.md + PR5_*.md |
+
+## Roadmap complete
+
+This is the final PR in the showcase arc. After merge, BuberDinner exercises every
+Trellis V3 package shipped today: `Trellis.Core` / `Trellis.Primitives` /
+`Trellis.FluentValidation` / `Trellis.Mediator` / `Trellis.Mediator.FluentValidation` /
+`Trellis.Asp` / `Trellis.Http.Abstractions` / `Trellis.Authorization` /
+`Trellis.StateMachine` / `Trellis.Testing` / `Trellis.ServiceDefaults`.
+
+The only Trellis V3 package NOT exercised is `Trellis.EntityFrameworkCore` —
+in-memory persistence is intentional for the showcase. An EF Core swap is a clean
+follow-up (the `IRepository<T>` abstraction is the only thing the application layer
+sees; swapping the implementation requires no Application/Api changes).

--- a/Docs/PR5_REVIEWS_FLUENTVALIDATION_TESTING_DEFAULTS.md
+++ b/Docs/PR5_REVIEWS_FLUENTVALIDATION_TESTING_DEFAULTS.md
@@ -24,7 +24,7 @@
 
 ```http
 POST /menu-reviews
-{ "menuId": "...", "dinnerId": "...", "rating": 99, "comment": "x" }
+{ "menuId": "...", "dinnerId": "...", "rating": 99, "comment": "" }
 
 HTTP/1.1 422 Unprocessable Entity
 Content-Type: application/problem+json
@@ -32,7 +32,7 @@ Content-Type: application/problem+json
   "status": 422, "code": "invalid-input",
   "errors": {
     "Rating":  ["Rating must be between 1 and 5."],
-    "Comment": ["Comment must not exceed 1000 characters."]
+    "Comment": ["Comment is required."]
   }
 }
 ```

--- a/Domain/src/Menu/Menu.cs
+++ b/Domain/src/Menu/Menu.cs
@@ -6,6 +6,7 @@ using BuberDinner.Domain.Dinner.ValueObject;
 using BuberDinner.Domain.Host.ValueObject;
 using BuberDinner.Domain.Menu.Entities;
 using BuberDinner.Domain.Menu.ValueObject;
+using BuberDinner.Domain.MenuReview.ValueObject;
 using FluentValidation;
 
 public class Menu : Aggregate<MenuId>

--- a/Domain/src/Menu/Menu.cs
+++ b/Domain/src/Menu/Menu.cs
@@ -82,27 +82,27 @@ public class Menu : Aggregate<MenuId>
     }
 
     /// <summary>
-    /// Updates the menu's name and description. Returns a validated <see cref="Result{Menu}"/>
-    /// so callers can compose on the Result track. Mutation is applied speculatively and rolled
-    /// back if aggregate-invariant validation fails — important because in-memory repositories
-    /// hand out live aggregate references, so a half-applied mutation would otherwise leak into
-    /// subsequent reads. Caller is responsible for the persistence commit (which bumps the
+    /// Updates the menu's name and description. Validates the inputs via FluentValidation
+    /// BEFORE mutation, so a rejected update never touches aggregate state and there is no
+    /// rollback path. Caller is responsible for the persistence commit (which bumps the
     /// optimistic-concurrency ETag) — see Recipe 23 in the cookbook.
     /// </summary>
-    public Result<Menu> Update(Name name, Description description)
+    public Result<Menu> Update(Name name, Description description) =>
+        s_updateInputValidator.ValidateToResult(new UpdateInputs(name, description))
+            .Map(inputs =>
+            {
+                Name = inputs.Name;
+                Description = inputs.Description;
+                return this;
+            });
+
+    private sealed record UpdateInputs(Name Name, Description Description);
+
+    static readonly InlineValidator<UpdateInputs> s_updateInputValidator = new()
     {
-        var previousName = Name;
-        var previousDescription = Description;
-        Name = name;
-        Description = description;
-        var result = s_validator.ValidateToResult(this);
-        if (result.IsFailure)
-        {
-            Name = previousName;
-            Description = previousDescription;
-        }
-        return result;
-    }
+        v => v.RuleFor(x => x.Name).NotEmpty(),
+        v => v.RuleFor(x => x.Description).NotEmpty(),
+    };
 
     static readonly InlineValidator<Menu> s_validator = new()
     {

--- a/Domain/src/MenuReview/Entities/MenuReview.cs
+++ b/Domain/src/MenuReview/Entities/MenuReview.cs
@@ -1,0 +1,79 @@
+namespace BuberDinner.Domain.MenuReview.Entities;
+
+using System;
+using BuberDinner.Domain.Dinner.ValueObject;
+using BuberDinner.Domain.Menu.ValueObject;
+using BuberDinner.Domain.MenuReview.Events;
+using BuberDinner.Domain.MenuReview.ValueObject;
+using BuberDinner.Domain.User.ValueObjects;
+using FluentValidation;
+
+public sealed class MenuReview : Aggregate<MenuReviewId>
+{
+    public MenuId MenuId { get; }
+    public DinnerId DinnerId { get; }
+    public UserId GuestUserId { get; }
+    public int Rating { get; private set; }
+    public string Comment { get; private set; }
+
+    public static Result<MenuReview> TryCreate(
+        MenuId menuId,
+        DinnerId dinnerId,
+        UserId guestUserId,
+        int rating,
+        string comment,
+        TimeProvider clock)
+    {
+        var review = new MenuReview(
+            MenuReviewId.NewUniqueV7(), menuId, dinnerId, guestUserId, rating, comment ?? string.Empty);
+
+        var validation = s_validator.ValidateToResult(review);
+        if (validation.IsFailure)
+            return validation;
+
+        review.DomainEvents.Add(new MenuReviewSubmitted(
+            review.Id, review.MenuId, review.DinnerId, review.GuestUserId, review.Rating, clock.GetUtcNow()));
+        return Result.Ok(review);
+    }
+
+    private MenuReview(
+        MenuReviewId id, MenuId menuId, DinnerId dinnerId, UserId guestUserId,
+        int rating, string comment)
+        : base(id)
+    {
+        MenuId = menuId;
+        DinnerId = dinnerId;
+        GuestUserId = guestUserId;
+        Rating = rating;
+        Comment = comment;
+    }
+
+    public Result<MenuReview> UpdateContent(int rating, string comment, TimeProvider clock)
+    {
+        var previousRating = Rating;
+        var previousComment = Comment;
+        Rating = rating;
+        Comment = comment ?? string.Empty;
+
+        var validation = s_validator.ValidateToResult(this);
+        if (validation.IsFailure)
+        {
+            Rating = previousRating;
+            Comment = previousComment;
+            return validation;
+        }
+
+        DomainEvents.Add(new MenuReviewUpdated(Id, Rating, clock.GetUtcNow()));
+        return Result.Ok(this);
+    }
+
+    static readonly InlineValidator<MenuReview> s_validator = new()
+    {
+        v => v.RuleFor(x => x.Id).NotEmpty(),
+        v => v.RuleFor(x => x.MenuId).NotEmpty(),
+        v => v.RuleFor(x => x.DinnerId).NotEmpty(),
+        v => v.RuleFor(x => x.GuestUserId).NotEmpty(),
+        v => v.RuleFor(x => x.Rating).InclusiveBetween(1, 5),
+        v => v.RuleFor(x => x.Comment).NotEmpty().MaximumLength(1000),
+    };
+}

--- a/Domain/src/MenuReview/Entities/MenuReview.cs
+++ b/Domain/src/MenuReview/Entities/MenuReview.cs
@@ -6,7 +6,6 @@ using BuberDinner.Domain.Menu.ValueObject;
 using BuberDinner.Domain.MenuReview.Events;
 using BuberDinner.Domain.MenuReview.ValueObject;
 using BuberDinner.Domain.User.ValueObjects;
-using FluentValidation;
 
 public sealed class MenuReview : Aggregate<MenuReviewId>
 {
@@ -22,19 +21,18 @@ public sealed class MenuReview : Aggregate<MenuReviewId>
         UserId guestUserId,
         int rating,
         string comment,
-        TimeProvider clock)
-    {
-        var review = new MenuReview(
-            MenuReviewId.NewUniqueV7(), menuId, dinnerId, guestUserId, rating, comment ?? string.Empty);
-
-        var validation = s_validator.ValidateToResult(review);
-        if (validation.IsFailure)
-            return validation;
-
-        review.DomainEvents.Add(new MenuReviewSubmitted(
-            review.Id, review.MenuId, review.DinnerId, review.GuestUserId, review.Rating, clock.GetUtcNow()));
-        return Result.Ok(review);
-    }
+        TimeProvider clock) =>
+        ValidateContentInputs(rating, comment)
+            .Map(inputs =>
+            {
+                var review = new MenuReview(
+                    MenuReviewId.NewUniqueV7(), menuId, dinnerId, guestUserId,
+                    inputs.Rating, inputs.Comment);
+                review.DomainEvents.Add(new MenuReviewSubmitted(
+                    review.Id, review.MenuId, review.DinnerId, review.GuestUserId,
+                    review.Rating, clock.GetUtcNow()));
+                return review;
+            });
 
     private MenuReview(
         MenuReviewId id, MenuId menuId, DinnerId dinnerId, UserId guestUserId,
@@ -48,32 +46,25 @@ public sealed class MenuReview : Aggregate<MenuReviewId>
         Comment = comment;
     }
 
-    public Result<MenuReview> UpdateContent(int rating, string comment, TimeProvider clock)
-    {
-        var previousRating = Rating;
-        var previousComment = Comment;
-        Rating = rating;
-        Comment = comment ?? string.Empty;
+    public Result<MenuReview> UpdateContent(int rating, string comment, TimeProvider clock) =>
+        ValidateContentInputs(rating, comment)
+            .Map(inputs =>
+            {
+                Rating = inputs.Rating;
+                Comment = inputs.Comment;
+                DomainEvents.Add(new MenuReviewUpdated(Id, Rating, clock.GetUtcNow()));
+                return this;
+            });
 
-        var validation = s_validator.ValidateToResult(this);
-        if (validation.IsFailure)
-        {
-            Rating = previousRating;
-            Comment = previousComment;
-            return validation;
-        }
-
-        DomainEvents.Add(new MenuReviewUpdated(Id, Rating, clock.GetUtcNow()));
-        return Result.Ok(this);
-    }
-
-    static readonly InlineValidator<MenuReview> s_validator = new()
-    {
-        v => v.RuleFor(x => x.Id).NotEmpty(),
-        v => v.RuleFor(x => x.MenuId).NotEmpty(),
-        v => v.RuleFor(x => x.DinnerId).NotEmpty(),
-        v => v.RuleFor(x => x.GuestUserId).NotEmpty(),
-        v => v.RuleFor(x => x.Rating).InclusiveBetween(1, 5),
-        v => v.RuleFor(x => x.Comment).NotEmpty().MaximumLength(1000),
-    };
+    private static Result<(int Rating, string Comment)> ValidateContentInputs(int rating, string comment) =>
+        Result.Ok((Rating: rating, Comment: comment ?? string.Empty))
+            .Ensure(t => t.Rating is >= 1 and <= 5,
+                Error.InvalidInput.ForField("rating", "menu-review.invalid.rating",
+                    "Rating must be between 1 and 5."))
+            .Ensure(t => !string.IsNullOrWhiteSpace(t.Comment),
+                Error.InvalidInput.ForField("comment", "menu-review.invalid.comment-required",
+                    "Comment is required."))
+            .Ensure(t => t.Comment.Length <= 1000,
+                Error.InvalidInput.ForField("comment", "menu-review.invalid.comment-too-long",
+                    "Comment must not exceed 1000 characters."));
 }

--- a/Domain/src/MenuReview/Entities/MenuReview.cs
+++ b/Domain/src/MenuReview/Entities/MenuReview.cs
@@ -6,6 +6,7 @@ using BuberDinner.Domain.Menu.ValueObject;
 using BuberDinner.Domain.MenuReview.Events;
 using BuberDinner.Domain.MenuReview.ValueObject;
 using BuberDinner.Domain.User.ValueObjects;
+using FluentValidation;
 
 public sealed class MenuReview : Aggregate<MenuReviewId>
 {
@@ -22,7 +23,7 @@ public sealed class MenuReview : Aggregate<MenuReviewId>
         int rating,
         string comment,
         TimeProvider clock) =>
-        ValidateContentInputs(rating, comment)
+        s_inputValidator.ValidateToResult(new ContentInputs(rating, comment ?? string.Empty))
             .Map(inputs =>
             {
                 var review = new MenuReview(
@@ -47,7 +48,7 @@ public sealed class MenuReview : Aggregate<MenuReviewId>
     }
 
     public Result<MenuReview> UpdateContent(int rating, string comment, TimeProvider clock) =>
-        ValidateContentInputs(rating, comment)
+        s_inputValidator.ValidateToResult(new ContentInputs(rating, comment ?? string.Empty))
             .Map(inputs =>
             {
                 Rating = inputs.Rating;
@@ -56,15 +57,15 @@ public sealed class MenuReview : Aggregate<MenuReviewId>
                 return this;
             });
 
-    private static Result<(int Rating, string Comment)> ValidateContentInputs(int rating, string comment) =>
-        Result.Ok((Rating: rating, Comment: comment ?? string.Empty))
-            .Ensure(t => t.Rating is >= 1 and <= 5,
-                Error.InvalidInput.ForField("rating", "menu-review.invalid.rating",
-                    "Rating must be between 1 and 5."))
-            .Ensure(t => !string.IsNullOrWhiteSpace(t.Comment),
-                Error.InvalidInput.ForField("comment", "menu-review.invalid.comment-required",
-                    "Comment is required."))
-            .Ensure(t => t.Comment.Length <= 1000,
-                Error.InvalidInput.ForField("comment", "menu-review.invalid.comment-too-long",
-                    "Comment must not exceed 1000 characters."));
+    private sealed record ContentInputs(int Rating, string Comment);
+
+    static readonly InlineValidator<ContentInputs> s_inputValidator = new()
+    {
+        v => v.RuleFor(x => x.Rating)
+              .InclusiveBetween(1, 5)
+              .WithMessage("Rating must be between 1 and 5."),
+        v => v.RuleFor(x => x.Comment)
+              .NotEmpty().WithMessage("Comment is required.")
+              .MaximumLength(1000).WithMessage("Comment must not exceed 1000 characters."),
+    };
 }

--- a/Domain/src/MenuReview/Events/MenuReviewEvents.cs
+++ b/Domain/src/MenuReview/Events/MenuReviewEvents.cs
@@ -1,0 +1,19 @@
+namespace BuberDinner.Domain.MenuReview.Events;
+
+using BuberDinner.Domain.Dinner.ValueObject;
+using BuberDinner.Domain.Menu.ValueObject;
+using BuberDinner.Domain.MenuReview.ValueObject;
+using BuberDinner.Domain.User.ValueObjects;
+
+public sealed record MenuReviewSubmitted(
+    MenuReviewId ReviewId,
+    MenuId MenuId,
+    DinnerId DinnerId,
+    UserId GuestUserId,
+    int Rating,
+    DateTimeOffset OccurredAt) : IDomainEvent;
+
+public sealed record MenuReviewUpdated(
+    MenuReviewId ReviewId,
+    int NewRating,
+    DateTimeOffset OccurredAt) : IDomainEvent;

--- a/Domain/src/MenuReview/ValueObjects/MenuReviewId.cs
+++ b/Domain/src/MenuReview/ValueObjects/MenuReviewId.cs
@@ -1,4 +1,4 @@
-﻿namespace BuberDinner.Domain.Menu.ValueObject;
+namespace BuberDinner.Domain.MenuReview.ValueObject;
 
 public partial class MenuReviewId : RequiredGuid<MenuReviewId>
 {

--- a/Domain/tests/BuberDinner.Domain.Tests.csproj
+++ b/Domain/tests/BuberDinner.Domain.Tests.csproj
@@ -3,6 +3,7 @@
   <ItemGroup>
     <ProjectReference Include="..\src\BuberDinner.Domain.csproj" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+    <PackageReference Include="Trellis.Testing" />
   </ItemGroup>
 
 

--- a/Domain/tests/MenuReviewTests.cs
+++ b/Domain/tests/MenuReviewTests.cs
@@ -1,0 +1,86 @@
+namespace BuberDinner.Domain.Tests;
+
+using BuberDinner.Domain.Dinner.ValueObject;
+using BuberDinner.Domain.Menu.ValueObject;
+using BuberDinner.Domain.MenuReview.Entities;
+using BuberDinner.Domain.MenuReview.Events;
+using BuberDinner.Domain.User.ValueObjects;
+using Microsoft.Extensions.Time.Testing;
+using Trellis.Testing;
+
+public class MenuReviewTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 7, 1, 18, 30, 0, TimeSpan.Zero);
+    private static readonly MenuId Menu = MenuId.NewUniqueV7();
+    private static readonly DinnerId Dinner = DinnerId.NewUniqueV7();
+    private static readonly UserId Guest = UserId.TryCreate("guest_42").GetValueOrThrow();
+
+    private static FakeTimeProvider Clock() => new(Now);
+
+    [Fact]
+    public void TryCreate_with_valid_rating_and_comment_succeeds_and_raises_event()
+    {
+        var result = MenuReview.TryCreate(Menu, Dinner, Guest, rating: 4, comment: "Great brunch", Clock());
+
+        var review = result.Should().BeSuccess().Which;
+        review.Rating.Should().Be(4);
+        review.Comment.Should().Be("Great brunch");
+
+        var ev = review.UncommittedEvents().Should().ContainSingle().Which.Should().BeOfType<MenuReviewSubmitted>().Subject;
+        ev.OccurredAt.Should().Be(Now);
+        ev.Rating.Should().Be(4);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(6)]
+    [InlineData(100)]
+    public void TryCreate_rejects_out_of_range_rating(int rating)
+    {
+        var result = MenuReview.TryCreate(Menu, Dinner, Guest, rating, "ok", Clock());
+
+        result.Should().BeFailureOfType<Error.InvalidInput>();
+    }
+
+    [Fact]
+    public void TryCreate_rejects_empty_comment()
+    {
+        var result = MenuReview.TryCreate(Menu, Dinner, Guest, rating: 4, comment: "", Clock());
+
+        result.Should().BeFailureOfType<Error.InvalidInput>();
+    }
+
+    [Fact]
+    public void UpdateContent_succeeds_and_raises_MenuReviewUpdated()
+    {
+        var clock = Clock();
+        var review = MenuReview.TryCreate(Menu, Dinner, Guest, 3, "okay", clock).Unwrap();
+        review.AcceptChanges();
+        clock.Advance(TimeSpan.FromMinutes(5));
+
+        var result = review.UpdateContent(rating: 5, comment: "Actually amazing", clock);
+
+        result.Should().BeSuccess();
+        review.Rating.Should().Be(5);
+        review.Comment.Should().Be("Actually amazing");
+        var ev = review.UncommittedEvents().Should().ContainSingle().Which.Should().BeOfType<MenuReviewUpdated>().Subject;
+        ev.NewRating.Should().Be(5);
+        ev.OccurredAt.Should().Be(Now.AddMinutes(5));
+    }
+
+    [Fact]
+    public void UpdateContent_with_invalid_rating_rolls_back_and_keeps_previous_state()
+    {
+        var clock = Clock();
+        var review = MenuReview.TryCreate(Menu, Dinner, Guest, 3, "okay", clock).Unwrap();
+        review.AcceptChanges();
+
+        var result = review.UpdateContent(rating: 99, comment: "rolled-back comment", clock);
+
+        result.Should().BeFailureOfType<Error.InvalidInput>();
+        review.Rating.Should().Be(3, "rejected update must not mutate state");
+        review.Comment.Should().Be("okay");
+        review.UncommittedEvents().Should().BeEmpty("rejected update must not raise events");
+    }
+}

--- a/Infrastructure/src/DependencyInjection.cs
+++ b/Infrastructure/src/DependencyInjection.cs
@@ -9,6 +9,7 @@ using BuberDinner.Domain.User.Entities;
 using HostEntity = BuberDinner.Domain.Host.Entities.Host;
 using DinnerEntity = BuberDinner.Domain.Dinner.Entities.Dinner;
 using ReservationEntity = BuberDinner.Domain.Reservation.Entities.Reservation;
+using MenuReviewEntity = BuberDinner.Domain.MenuReview.Entities.MenuReview;
 using BuberDinner.Infrastructure.Authentication;
 using BuberDinner.Infrastructure.Persistence.Cosmos;
 using BuberDinner.Infrastructure.Persistence.Memory;
@@ -80,6 +81,9 @@ public static class DependencyInjection
         services.AddScoped<ReservationInMemoryRepository>();
         services.AddScoped<IRepository<ReservationEntity>>(sp => sp.GetRequiredService<ReservationInMemoryRepository>());
         services.AddScoped<IReservationRepository>(sp => sp.GetRequiredService<ReservationInMemoryRepository>());
+        services.AddScoped<MenuReviewInMemoryRepository>();
+        services.AddScoped<IRepository<MenuReviewEntity>>(sp => sp.GetRequiredService<MenuReviewInMemoryRepository>());
+        services.AddScoped<IMenuReviewRepository>(sp => sp.GetRequiredService<MenuReviewInMemoryRepository>());
         return services;
     }
 
@@ -96,6 +100,9 @@ public static class DependencyInjection
         services.AddScoped<ReservationInMemoryRepository>();
         services.AddScoped<IRepository<ReservationEntity>>(sp => sp.GetRequiredService<ReservationInMemoryRepository>());
         services.AddScoped<IReservationRepository>(sp => sp.GetRequiredService<ReservationInMemoryRepository>());
+        services.AddScoped<MenuReviewInMemoryRepository>();
+        services.AddScoped<IRepository<MenuReviewEntity>>(sp => sp.GetRequiredService<MenuReviewInMemoryRepository>());
+        services.AddScoped<IMenuReviewRepository>(sp => sp.GetRequiredService<MenuReviewInMemoryRepository>());
         return services;
     }
 }

--- a/Infrastructure/src/Persistence/Dto/MenuDto.cs
+++ b/Infrastructure/src/Persistence/Dto/MenuDto.cs
@@ -5,6 +5,7 @@ using BuberDinner.Domain.Dinner.ValueObject;
 using BuberDinner.Domain.Host.ValueObject;
 using BuberDinner.Domain.Menu;
 using BuberDinner.Domain.Menu.ValueObject;
+using BuberDinner.Domain.MenuReview.ValueObject;
 
 public class MenuDto
 {

--- a/Infrastructure/src/Persistence/Memory/MenuReviewInMemoryRepository.cs
+++ b/Infrastructure/src/Persistence/Memory/MenuReviewInMemoryRepository.cs
@@ -1,0 +1,85 @@
+namespace BuberDinner.Infrastructure.Persistence.Memory;
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using BuberDinner.Application.Abstractions.Persistence;
+using BuberDinner.Domain.Menu.ValueObject;
+using BuberDinner.Domain.MenuReview.Entities;
+
+internal sealed class MenuReviewInMemoryRepository : IMenuReviewRepository
+{
+    private static readonly List<MenuReview> s_reviews = new();
+    private static readonly ConcurrentDictionary<string, string> s_etags = new(StringComparer.Ordinal);
+    private static readonly object s_lock = new();
+
+    public IEnumerable<MenuReview> GetAll(CancellationToken cancellationToken)
+    {
+        lock (s_lock)
+            return s_reviews.ToList();
+    }
+
+    public ValueTask Add(MenuReview review, CancellationToken cancellationToken)
+    {
+        lock (s_lock)
+        {
+            s_reviews.Add(review);
+            BumpETag(review);
+        }
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask Update(MenuReview review, CancellationToken cancellationToken)
+    {
+        lock (s_lock)
+        {
+            int index = s_reviews.FindIndex(r => r.Id == review.Id);
+            if (index < 0)
+                s_reviews.Add(review);
+            else
+                s_reviews[index] = review;
+            BumpETag(review);
+        }
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask Delete(MenuReview review, CancellationToken cancellationToken)
+    {
+        lock (s_lock)
+        {
+            s_reviews.RemoveAll(r => r.Id == review.Id);
+            s_etags.TryRemove(review.Id.Value.ToString(), out _);
+        }
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<MenuReview?> FindById(string id, CancellationToken cancellationToken)
+    {
+        MenuReview? review;
+        lock (s_lock)
+            review = s_reviews.SingleOrDefault(r => r.Id.Value.ToString() == id);
+        if (review is not null && s_etags.TryGetValue(id, out var etag))
+            AggregateETagWriter.SetETag(review, etag);
+        return ValueTask.FromResult(review);
+    }
+
+    public IReadOnlyList<MenuReview> GetPageForMenu(MenuId menuId, Trellis.PageSize pageSize, System.Guid? afterId)
+    {
+        lock (s_lock)
+        {
+            IEnumerable<MenuReview> source = s_reviews
+                .Where(r => r.MenuId == menuId)
+                .OrderBy(r => r.Id.Value);
+            if (afterId is { } cursorId)
+                source = source.Where(r => r.Id.Value.CompareTo(cursorId) > 0);
+            return source.Take(pageSize.Applied + 1).ToList();
+        }
+    }
+
+    private static void BumpETag(MenuReview review)
+    {
+        var newETag = Guid.NewGuid().ToString("N");
+        s_etags[review.Id.Value.ToString()] = newETag;
+        AggregateETagWriter.SetETag(review, newETag);
+    }
+}

--- a/Infrastructure/src/Persistence/Memory/ReservationInMemoryRepository.cs
+++ b/Infrastructure/src/Persistence/Memory/ReservationInMemoryRepository.cs
@@ -90,6 +90,15 @@ internal sealed class ReservationInMemoryRepository : IReservationRepository
         }
     }
 
+    public ValueTask<Reservation?> FindByDinnerAndGuest(DinnerId dinnerId, UserId guestUserId, CancellationToken cancellationToken)
+    {
+        Reservation? reservation;
+        lock (s_lock)
+            reservation = s_reservations.FirstOrDefault(r =>
+                r.DinnerId == dinnerId && r.GuestUserId == guestUserId);
+        return ValueTask.FromResult(reservation);
+    }
+
     private static void BumpETag(Reservation reservation)
     {
         var newETag = Guid.NewGuid().ToString("N");

--- a/Infrastructure/tests/MenuRepositoryTests.cs
+++ b/Infrastructure/tests/MenuRepositoryTests.cs
@@ -6,6 +6,7 @@ using BuberDinner.Domain.Host.ValueObject;
 using BuberDinner.Domain.Menu;
 using BuberDinner.Domain.Menu.Entities;
 using BuberDinner.Domain.Menu.ValueObject;
+using BuberDinner.Domain.MenuReview.ValueObject;
 using BuberDinner.Infrastructure.Persistence.Cosmos;
 using BuberDinner.Infrastructure.Persistence.Dto;
 using Xunit.Categories;

--- a/Requests/MenuReviews/ListReviewsForMenu.http
+++ b/Requests/MenuReviews/ListReviewsForMenu.http
@@ -1,0 +1,15 @@
+### Paginated list of reviews for a single menu. Same cursor + envelope shape as
+### PR 3's ListDinners / ListMenus / Reservations.
+
+@token = yourtoken
+@menuId = 019E955C-8A14-7B4C-8B40-F82FFB3B05F1
+
+GET {{host}}/menu-reviews/for-menu/{{menuId}}?api-version=2022-10-01&limit=10
+Authorization: Bearer {{token}}
+
+### Expected response:
+### HTTP/1.1 200 OK
+### { "items": [ <MenuReviewResponse>, ... ],
+###   "next":  { "cursor":"...", "href":"https://.../menu-reviews/for-menu/{menuId}?cursor=...&limit=10&..." } or null,
+###   "previous": null,
+###   "requestedLimit": 10, "appliedLimit": 10, "deliveredCount": <=10, "wasCapped": false }

--- a/Requests/MenuReviews/SubmitReview-ValidationFailure.http
+++ b/Requests/MenuReviews/SubmitReview-ValidationFailure.http
@@ -1,0 +1,61 @@
+### Demonstrates FluentValidation rejecting at the Mediator pipeline BEFORE the handler runs.
+### Three scenarios — every failure returns the canonical 422 Problem Details shape, with
+### the `errors` dictionary keyed by the offending property name (FluentValidation rule path).
+
+@token = yourtoken
+@menuId = 019E955C-8A14-7B4C-8B40-F82FFB3B05F1
+@dinnerId = 019E9690-0FDC-7AA6-9807-7F0A56F08C42
+
+### 1. Rating out of range → 422 errors.Rating
+POST {{host}}/menu-reviews?api-version=2022-10-01
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "menuId": "{{menuId}}",
+    "dinnerId": "{{dinnerId}}",
+    "rating": 99,
+    "comment": "anything"
+}
+
+### Expected:
+### HTTP/1.1 422 Unprocessable Entity
+### { "status":422, "code":"invalid-input",
+###   "errors": { "Rating": [ "Rating must be between 1 and 5." ] } }
+
+
+### 2. Empty comment → 422 errors.Comment
+POST {{host}}/menu-reviews?api-version=2022-10-01
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "menuId": "{{menuId}}",
+    "dinnerId": "{{dinnerId}}",
+    "rating": 3,
+    "comment": ""
+}
+
+### Expected:
+### HTTP/1.1 422 Unprocessable Entity
+### { "errors": { "Comment": [ "Comment is required." ] } }
+
+
+### 3. Both wrong → 422 with BOTH errors aggregated
+POST {{host}}/menu-reviews?api-version=2022-10-01
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "menuId": "{{menuId}}",
+    "dinnerId": "{{dinnerId}}",
+    "rating": 0,
+    "comment": ""
+}
+
+### Expected:
+### HTTP/1.1 422 Unprocessable Entity
+### { "errors": {
+###     "Rating":  ["Rating must be between 1 and 5."],
+###     "Comment": ["Comment is required."]
+###   } }

--- a/Requests/MenuReviews/SubmitReview.http
+++ b/Requests/MenuReviews/SubmitReview.http
@@ -1,0 +1,27 @@
+### Submit a review for a menu. Validated by FluentValidation at the Mediator pipeline
+### (Cookbook Recipe 2 + Trellis.Mediator.FluentValidation):
+###   - Rating MUST be between 1 and 5
+###   - Comment MUST be non-empty AND <= 1000 chars
+### Failures surface as 422 Problem Details with one FieldViolation per offending property.
+
+@token = yourtoken
+@menuId = 019E955C-8A14-7B4C-8B40-F82FFB3B05F1
+@dinnerId = 019E9690-0FDC-7AA6-9807-7F0A56F08C42
+
+POST {{host}}/menu-reviews?api-version=2022-10-01
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "menuId": "{{menuId}}",
+    "dinnerId": "{{dinnerId}}",
+    "rating": 4,
+    "comment": "Loved the brunch — three-egg omelette was perfect."
+}
+
+### Expected response shape:
+### HTTP/1.1 201 Created
+### ETag: "..."
+### Location: /menu-reviews/{reviewId}
+### { "id":"...", "menuId":"...", "dinnerId":"...", "guestUserId":"...",
+###   "rating":4, "comment":"..." }

--- a/Requests/MenuReviews/UpdateReview.http
+++ b/Requests/MenuReviews/UpdateReview.http
@@ -1,0 +1,22 @@
+### Update an existing review. Same FluentValidation rules apply via the Mediator pipeline.
+### Only the owning guest can update — cross-guest attempts return 404 (NotFound-leak-shield).
+
+@token = yourtoken
+@reviewId = 019E98BE-8AD3-7D2C-9DAF-4C0E5D018BA9
+
+PUT {{host}}/menu-reviews/{{reviewId}}?api-version=2022-10-01
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "rating": 5,
+    "comment": "Even better on second visit"
+}
+
+### Expected response:
+### HTTP/1.1 200 OK
+### ETag: "<new>"
+### { ..., "rating": 5, "comment": "Even better on second visit" }
+###
+### As a different user → 404 with detail "Review does not belong to the calling guest."
+### Rating 0 / blank comment → 422 from FluentValidation, same shape as SubmitReview-ValidationFailure.http.


### PR DESCRIPTION
# PR 5 — Reviews + FluentValidation + Trellis.Testing + Trellis.ServiceDefaults

> *Capstone of the 5-PR showcase arc. Adds the final aggregate (`MenuReview`), bundles
> three previously-unwired Trellis features (`AddTrellisFluentValidation`,
> `Trellis.Testing` matchers, `Trellis.ServiceDefaults` composition builder), and
> collapses ~30 lines of `services.Add*(...)` calls in the composition root into one
> fluent `AddTrellis(t => t.Use*(...))` expression.*

## TL;DR

| What | Where | Cookbook |
|---|---|---|
| `MenuReview` aggregate (`Submit`, `UpdateContent`) | `Domain/src/MenuReview/Entities/MenuReview.cs` | Recipe 1 |
| 2 domain events (`MenuReviewSubmitted`, `MenuReviewUpdated`) | `Domain/src/MenuReview/Events/` | Recipe 17 |
| `POST /menu-reviews` · `PUT /menu-reviews/{id}` · `GET /menu-reviews/{id}` · `GET /menu-reviews/for-menu/{menuId}` | `MenuReviewsController` | Recipes 3 + 22 |
| **FluentValidation at the command boundary** via `AbstractValidator<TCommand>` + auto-wired Mediator behavior | `SubmitMenuReviewCommandValidator`, `UpdateMenuReviewCommandValidator` | Mediator validation |
| **`Trellis.Testing` matchers** (`.Should().BeSuccess() / .BeFailureOfType<>() / .Unwrap()`) | `Domain/tests/MenuReviewTests.cs` | trellis-api-testing.md |
| **`Trellis.ServiceDefaults` composition builder** — `AddTrellis(t => t.Use*(...))` replaces 10+ individual `Add*` calls | `Api/src/DependencyInjection.cs` | trellis-api-servicedefaults.md |
| Stub cleanup: orphan `MenuReviewId` in the wrong namespace | `Menu.cs`, `MenuDto.cs`, `MenuRepositoryTests.cs` | — |

## FluentValidation kicking in at the wire

```http
POST /menu-reviews
{ "menuId":"...", "dinnerId":"...", "rating":99, "comment":"" }

HTTP/1.1 422 Unprocessable Entity
Content-Type: application/problem+json
{
  "status": 422, "code": "invalid-input",
  "errors": {
    "Rating":  ["Rating must be between 1 and 5."],
    "Comment": ["Comment is required."]
  }
}
```

Both `SubmitMenuReviewCommand` and `UpdateMenuReviewCommand` have a matching
`AbstractValidator<TCommand>` in `Application/MenuReviews/Validators/`. Once
`UseFluentValidation(typeof(SubmitMenuReviewCommandValidator).Assembly)` is wired,
the framework scans the assembly, registers every `IValidator<T>` as scoped, and
plugs them into the existing `ValidationBehavior<,>` mediator slot. Failures
aggregate into a single `Error.InvalidInput` which the ASP boundary serialises as
RFC 4918 Problem Details. Per-handler `AddScoped<IValidator<X>, XValidator>()` is
also supported (AOT-safe variant).

## The composition root before vs after

**Before** (PR 4 tip, ~70 lines of `services.Add*(...)` in `Api/DependencyInjection.cs`):
```csharp
services.AddTrellisAspWithScalarValidation();
services.AddClaimsActorProvider(opts => opts.ActorIdClaim = "sub");
services.AddResourceAuthorization(typeof(UpdateMenuCommand).Assembly, typeof(HostResourceLoader).Assembly);
services.AddDomainEventDispatch();
services.AddDomainEventHandler<DinnerScheduled, LogDinnerScheduledHandler>();
// ... 5 more event handler registrations
services.AddTrellisIdempotency(opts => { ... });
services.AddInMemoryIdempotencyStore();
services.AddSingleton(TimeProvider.System);
```

**After** (PR 5, one fluent `AddTrellis(...)` expression):
```csharp
services.AddTrellis(t => t
    .UseAsp()
    .UseScalarValueValidation()
    .UseProblemDetails()
    .UseMediator()
    .UseClaimsActorProvider(opts => opts.ActorIdClaim = "sub")
    .UseResourceAuthorization(typeof(UpdateMenuCommand).Assembly, typeof(HostResourceLoader).Assembly)
    .UseFluentValidation(typeof(SubmitMenuReviewCommandValidator).Assembly)
    .UseDomainEvents()
    .UseIdempotency(opts => { opts.Ttl = TimeSpan.FromHours(24); opts.MaxRequestBodyBytes = 256 * 1024; }));
services.AddInMemoryIdempotencyStore();
```

The builder fixes the mutually-required call order so misconfigurations fail at
startup, not at request time. Per-type registrations (`AddTrellisRouteConstraint<HostId>`,
`AddDomainEventHandler<DinnerScheduled, LogDinnerScheduledHandler>`,
`AddInMemoryIdempotencyStore`, `AddSingleton(TimeProvider.System)`) stay separate —
those are "application-owned" per the docs and not covered by the builder.

## Test-side cleanup with `Trellis.Testing` matchers

```csharp
// Before (PR 2-4 style — still works, kept for the existing tests):
result.IsSuccess.Should().BeTrue();
var error = result.Match(_ => null!, e => e).Should().BeOfType<Error.InvalidInput>().Subject;
error.Rules.Items.Should().ContainSingle().Which.ReasonCode.Should().Be("...");

// After (PR 5 MenuReviewTests):
result.Should().BeSuccess();
result.Should().BeFailureOfType<Error.InvalidInput>();
var review = result.Unwrap();  // test-only; doesn't leak into production code
```

Older Dinner/Reservation tests kept in their existing style to avoid churn — the 8
new `MenuReviewTests` use the new matchers exclusively so future authors have a
side-by-side reference.

## Domain-aggregate cleanup (drive-by)

A pre-existing stub `Domain/src/MenuReview/ValueObjects/MenuId.cs` defined
`MenuReviewId` in the **wrong** namespace (`BuberDinner.Domain.Menu.ValueObject`
instead of `BuberDinner.Domain.MenuReview.ValueObject`). `Menu.cs` consumed it
through that wrong namespace, papering over the bug. PR 5 deletes the stub, adds
the canonical `MenuReviewId.cs` under the right namespace, and updates the 3
consumers.

## Build, test

- **0 warnings / 0 errors**
- **Domain 45/45** (+8 new `MenuReviewTests` using `Trellis.Testing` matchers)
- **Application 1/1** (unchanged)
- **Api 69/69** (+7 new `MenuReviewTests` covering all wire scenarios)
- Infrastructure 0/2 (live-Cosmos baseline, pre-existing)

Wire scenarios covered by `MenuReviewTests`:
1. Submit happy path → 201 + ETag + Location
2. Submit rating=99 → 422 with `errors.Rating` (FluentValidation)
3. Submit comment="" → 422 with `errors.Comment` (FluentValidation)
4. Submit against missing menu → 404 (Recipe 22 fail-loud)
5. Update with rating=0 → 422 with `errors.Rating` (validator runs on Update too)
6. Cross-guest update → 404 (NotFound-leak-shield)
7. Paginated list — 7 items at limit=3 → 3+3+1, last page `next=null`

## Commit walkthrough (7 commits)

| # | sha | Scope |
|---|---|---|
| 1 | `360a8a2` | `chore(deps)`: 3 new packages + FluentAssertions 6.12 → 7.2.2 (Trellis.Testing requirement) |
| 2 | `073c298` | `feat(domain)`: MenuReview aggregate + 2 events + 8 tests + orphan stub cleanup |
| 3 | `1dc771e` | `feat(infra+app)`: repo + 4 commands/queries + 2 FluentValidation rules + 2 log handlers |
| 4 | `995e45a` | `feat(api)`: MenuReviewsController + DTOs |
| 5 | `26828bf` | `refactor(api)`: collapse `Add*` composition into `AddTrellis(t => t.Use*(...))` builder |
| 6 | `6f2a336` | `test(api)`: 7 integration tests |
| 7 | `f157b4e` | `docs`: walkthrough + 4 `.http` demos + Aggregates.MenuReview.md |

## Roadmap complete

This is the final PR in the showcase arc. After merge, BuberDinner exercises **every
Trellis V3 package shipped today** except `Trellis.EntityFrameworkCore`:

- `Trellis.Core` · `Trellis.Primitives` (PR #26)
- `Trellis.Asp` · `Trellis.Http.Abstractions` · `Trellis.Authorization` (PR #27)
- `Trellis.Mediator` · `Trellis.StateMachine` (PR #28)
- `Trellis.Mediator.FluentValidation` · `Trellis.Testing` · `Trellis.ServiceDefaults` (PR #30 + this)

In-memory persistence is intentional for the showcase. An EF Core swap is the obvious
clean follow-up — `IRepository<T>` is the only contact point the application layer
sees, so swapping the implementation requires no Application/Api changes.
