### PR TITLE
refactor: ROP sweep across Domain + Application (10 sites)

### DIFF
--- a/Application/src/Dinners/Commands/DinnerTransitionCommandHandlers.cs
+++ b/Application/src/Dinners/Commands/DinnerTransitionCommandHandlers.cs
@@ -18,24 +18,24 @@ internal static class DinnerTransitionPipeline
         BuberDinner.Domain.Host.ValueObject.HostId expectedHostId,
         BuberDinner.Domain.Dinner.ValueObject.DinnerId dinnerId,
         Func<Dinner, Result<Dinner>> transition,
-        CancellationToken cancellationToken)
-    {
-        var dinner = await repo.FindById(dinnerId.Value.ToString(), cancellationToken);
-        if (dinner is null)
-            return Result.Fail<Dinner>(new Error.NotFound(ResourceRef.For<Dinner>(dinnerId)));
-        if (dinner.HostId != expectedHostId)
-            return Result.Fail<Dinner>(new Error.NotFound(ResourceRef.For<Dinner>(dinnerId))
-            {
-                Detail = "Dinner does not belong to the specified host.",
-            });
+        CancellationToken cancellationToken) =>
+        await LoadOwnedDinnerAsync(repo, dinnerId, expectedHostId, cancellationToken)
+            .BindAsync(dinner => transition(dinner))
+            .TapAsync(dinner => repo.Update(dinner, cancellationToken));
 
-        var transitionResult = transition(dinner);
-        if (transitionResult.IsFailure)
-            return transitionResult;
-
-        await repo.Update(dinner, cancellationToken);
-        return transitionResult;
-    }
+    private static async ValueTask<Result<Dinner>> LoadOwnedDinnerAsync(
+        IRepository<Dinner> repo,
+        BuberDinner.Domain.Dinner.ValueObject.DinnerId dinnerId,
+        BuberDinner.Domain.Host.ValueObject.HostId expectedHostId,
+        CancellationToken cancellationToken) =>
+        (await repo.FindById(dinnerId.Value.ToString(), cancellationToken))
+            .ToResult(new Error.NotFound(ResourceRef.For<Dinner>(dinnerId)))
+            .Ensure(
+                d => d.HostId == expectedHostId,
+                new Error.NotFound(ResourceRef.For<Dinner>(dinnerId))
+                {
+                    Detail = "Dinner does not belong to the specified host.",
+                });
 }
 
 public sealed class StartDinnerCommandHandler : ICommandHandler<StartDinnerCommand, Result<Dinner>>

--- a/Application/src/Dinners/Commands/ScheduleDinnerCommandHandler.cs
+++ b/Application/src/Dinners/Commands/ScheduleDinnerCommandHandler.cs
@@ -5,14 +5,16 @@ using System.Threading;
 using System.Threading.Tasks;
 using BuberDinner.Application.Abstractions.Persistence;
 using BuberDinner.Domain.Dinner.Entities;
+using BuberDinner.Domain.Host.ValueObject;
 using BuberDinner.Domain.Menu;
+using BuberDinner.Domain.Menu.ValueObject;
 using Mediator;
 
 /// <summary>
-/// Handles <see cref="ScheduleDinnerCommand"/>: validates that the chosen <c>MenuId</c>
-/// belongs to the route <c>HostId</c>, builds the aggregate via <see cref="Dinner.TryCreate"/>,
-/// persists it, and lets <c>DomainEventDispatchBehavior</c> publish the
-/// <c>DinnerScheduled</c> event after the handler returns.
+/// Handles <see cref="ScheduleDinnerCommand"/>: verifies the menu exists and belongs to
+/// the route host, builds the aggregate via <see cref="Dinner.TryCreate"/>, persists it,
+/// and lets <c>DomainEventDispatchBehavior</c> publish the <c>DinnerScheduled</c> event
+/// after the handler returns.
 /// </summary>
 public sealed class ScheduleDinnerCommandHandler : ICommandHandler<ScheduleDinnerCommand, Result<Dinner>>
 {
@@ -30,32 +32,23 @@ public sealed class ScheduleDinnerCommandHandler : ICommandHandler<ScheduleDinne
         _clock = clock;
     }
 
-    public async ValueTask<Result<Dinner>> Handle(ScheduleDinnerCommand request, CancellationToken cancellationToken)
-    {
-        // Recipe 22 — fail-loud on missing related aggregate. Without this the create
-        // command would silently succeed against a non-existent menu, persisting an orphan
-        // dinner pointing at nothing. NotFound (not Forbidden) keeps existence private from
-        // the caller. The two cases — Menu missing vs Menu owned by another host — are
-        // detected separately so the Detail string accurately reflects which one fired.
-        var menu = await _menuRepository.FindById(request.MenuId.Value.ToString(), cancellationToken);
-        if (menu is null)
-            return Result.Fail<Dinner>(new Error.NotFound(ResourceRef.For<Menu>(request.MenuId)));
-        if (menu.HostId != request.HostId)
-            return Result.Fail<Dinner>(new Error.NotFound(ResourceRef.For<Menu>(request.MenuId))
-            {
-                Detail = "Menu does not belong to the specified host.",
-            });
+    public async ValueTask<Result<Dinner>> Handle(ScheduleDinnerCommand request, CancellationToken cancellationToken) =>
+        await LoadMenuOwnedByHostAsync(request.MenuId, request.HostId, cancellationToken)
+            .BindAsync(_ => Dinner.TryCreate(
+                request.Name, request.Description,
+                request.HostId, request.MenuId,
+                request.StartDateTime, request.EndDateTime,
+                _clock))
+            .TapAsync(dinner => _dinnerRepository.Add(dinner, cancellationToken));
 
-        var dinnerResult = Dinner.TryCreate(
-            request.Name, request.Description,
-            request.HostId, request.MenuId,
-            request.StartDateTime, request.EndDateTime,
-            _clock);
-        if (dinnerResult.IsFailure)
-            return dinnerResult;
-        var dinner = dinnerResult.GetValueOrThrow("dinner");
-
-        await _dinnerRepository.Add(dinner, cancellationToken);
-        return Result.Ok(dinner);
-    }
+    private async ValueTask<Result<Menu>> LoadMenuOwnedByHostAsync(
+        MenuId menuId, HostId hostId, CancellationToken cancellationToken) =>
+        (await _menuRepository.FindById(menuId.Value.ToString(), cancellationToken))
+            .ToResult(new Error.NotFound(ResourceRef.For<Menu>(menuId)))
+            .Ensure(
+                m => m.HostId == hostId,
+                new Error.NotFound(ResourceRef.For<Menu>(menuId))
+                {
+                    Detail = "Menu does not belong to the specified host.",
+                });
 }

--- a/Application/src/Dinners/Queries/GetDinnerQuery.cs
+++ b/Application/src/Dinners/Queries/GetDinnerQuery.cs
@@ -29,16 +29,13 @@ public sealed class GetDinnerQueryHandler : IRequestHandler<GetDinnerQuery, Resu
         _repo = repo;
     }
 
-    public async ValueTask<Result<Dinner>> Handle(GetDinnerQuery request, CancellationToken cancellationToken)
-    {
-        var dinner = await _repo.FindById(request.DinnerId.Value.ToString(), cancellationToken);
-        if (dinner is null)
-            return Result.Fail<Dinner>(new Error.NotFound(ResourceRef.For<Dinner>(request.DinnerId)));
-        if (dinner.HostId != request.HostId)
-            return Result.Fail<Dinner>(new Error.NotFound(ResourceRef.For<Dinner>(request.DinnerId))
-            {
-                Detail = "Dinner does not belong to the specified host.",
-            });
-        return Result.Ok(dinner);
-    }
+    public async ValueTask<Result<Dinner>> Handle(GetDinnerQuery request, CancellationToken cancellationToken) =>
+        (await _repo.FindById(request.DinnerId.Value.ToString(), cancellationToken))
+            .ToResult(new Error.NotFound(ResourceRef.For<Dinner>(request.DinnerId)))
+            .Ensure(
+                d => d.HostId == request.HostId,
+                new Error.NotFound(ResourceRef.For<Dinner>(request.DinnerId))
+                {
+                    Detail = "Dinner does not belong to the specified host.",
+                });
 }

--- a/Application/src/Hosts/Authorization/HostResourceLoader.cs
+++ b/Application/src/Hosts/Authorization/HostResourceLoader.cs
@@ -22,11 +22,7 @@ public sealed class HostResourceLoader : SharedResourceLoaderById<Host, HostId>
         _hostRepository = hostRepository;
     }
 
-    public override async Task<Result<Host>> GetByIdAsync(HostId id, CancellationToken cancellationToken)
-    {
-        var host = await _hostRepository.FindById(id.Value.ToString(), cancellationToken);
-        if (host is null)
-            return Result.Fail<Host>(new Error.NotFound(ResourceRef.For<Host>(id)));
-        return Result.Ok(host);
-    }
+    public override async Task<Result<Host>> GetByIdAsync(HostId id, CancellationToken cancellationToken) =>
+        (await _hostRepository.FindById(id.Value.ToString(), cancellationToken))
+            .ToResult(new Error.NotFound(ResourceRef.For<Host>(id)));
 }

--- a/Application/src/MenuReviews/Commands/SubmitMenuReviewCommandHandler.cs
+++ b/Application/src/MenuReviews/Commands/SubmitMenuReviewCommandHandler.cs
@@ -65,14 +65,17 @@ public sealed class SubmitMenuReviewCommandHandler
             .ToResult(new Error.NotFound(ResourceRef.For<Dinner>(dinnerId)));
 
     private async ValueTask<Result<Dinner>> EnsureCallerReservedAsync(
-        Dinner dinner, UserId guestUserId, CancellationToken cancellationToken)
-    {
-        var reservation = await _reservationRepository.FindByDinnerAndGuest(dinner.Id, guestUserId, cancellationToken);
-        if (reservation is null || reservation.Status != ReservationStatus.Reserved)
-            return Result.Fail<Dinner>(new Error.NotFound(ResourceRef.For<Dinner>(dinner.Id))
+        Dinner dinner, UserId guestUserId, CancellationToken cancellationToken) =>
+        (await _reservationRepository.FindByDinnerAndGuest(dinner.Id, guestUserId, cancellationToken))
+            .ToResult(new Error.NotFound(ResourceRef.For<Dinner>(dinner.Id))
             {
                 Detail = "Caller did not reserve this dinner.",
-            });
-        return Result.Ok(dinner);
-    }
+            })
+            .Ensure(
+                r => r.Status == ReservationStatus.Reserved,
+                new Error.NotFound(ResourceRef.For<Dinner>(dinner.Id))
+                {
+                    Detail = "Caller did not reserve this dinner.",
+                })
+            .Map(_ => dinner);
 }

--- a/Application/src/Menus/Commands/UpdateMenuCommandHandler.cs
+++ b/Application/src/Menus/Commands/UpdateMenuCommandHandler.cs
@@ -21,16 +21,13 @@ public sealed class UpdateMenuCommandHandler : IRequestHandler<UpdateMenuCommand
             .BindAsync(menu => menu.Update(request.Name, request.Description))
             .TapAsync(menu => _menuRepository.Update(menu, cancellationToken));
 
-    private async ValueTask<Result<Menu>> LoadMenuAsync(UpdateMenuCommand request, CancellationToken cancellationToken)
-    {
-        var menu = await _menuRepository.FindById(request.MenuId.Value.ToString(), cancellationToken);
-        if (menu is null)
-            return Result.Fail<Menu>(new Error.NotFound(ResourceRef.For<Menu>(request.MenuId)));
-        if (menu.HostId != request.HostId)
-            return Result.Fail<Menu>(new Error.NotFound(ResourceRef.For<Menu>(request.MenuId))
-            {
-                Detail = "Menu does not belong to the specified host.",
-            });
-        return Result.Ok(menu);
-    }
+    private async ValueTask<Result<Menu>> LoadMenuAsync(UpdateMenuCommand request, CancellationToken cancellationToken) =>
+        (await _menuRepository.FindById(request.MenuId.Value.ToString(), cancellationToken))
+            .ToResult(new Error.NotFound(ResourceRef.For<Menu>(request.MenuId)))
+            .Ensure(
+                m => m.HostId == request.HostId,
+                new Error.NotFound(ResourceRef.For<Menu>(request.MenuId))
+                {
+                    Detail = "Menu does not belong to the specified host.",
+                });
 }

--- a/Application/src/Menus/Queries/GetMenuQueryHandler.cs
+++ b/Application/src/Menus/Queries/GetMenuQueryHandler.cs
@@ -15,19 +15,13 @@ public sealed class GetMenuQueryHandler : IRequestHandler<GetMenuQuery, Result<M
         _menuRepository = menuRepository;
     }
 
-    public async ValueTask<Result<Menu>> Handle(GetMenuQuery request, CancellationToken cancellationToken)
-    {
-        var menu = await _menuRepository.FindById(request.MenuId.Value.ToString(), cancellationToken);
-        if (menu is null)
-            return Result.Fail<Menu>(new Error.NotFound(ResourceRef.For<Menu>(request.MenuId)));
-        // Hierarchical-route membership check: same as UpdateMenuCommandHandler. Returning
-        // NotFound (not Forbidden) keeps the response shape symmetric and avoids leaking the
-        // existence of menus the caller has no business asking about.
-        if (menu.HostId != request.HostId)
-            return Result.Fail<Menu>(new Error.NotFound(ResourceRef.For<Menu>(request.MenuId))
-            {
-                Detail = "Menu does not belong to the specified host.",
-            });
-        return Result.Ok(menu);
-    }
+    public async ValueTask<Result<Menu>> Handle(GetMenuQuery request, CancellationToken cancellationToken) =>
+        (await _menuRepository.FindById(request.MenuId.Value.ToString(), cancellationToken))
+            .ToResult(new Error.NotFound(ResourceRef.For<Menu>(request.MenuId)))
+            .Ensure(
+                m => m.HostId == request.HostId,
+                new Error.NotFound(ResourceRef.For<Menu>(request.MenuId))
+                {
+                    Detail = "Menu does not belong to the specified host.",
+                });
 }

--- a/Application/src/Reservations/Queries/ListReservationsForDinnerQuery.cs
+++ b/Application/src/Reservations/Queries/ListReservationsForDinnerQuery.cs
@@ -49,32 +49,37 @@ public sealed class ListReservationsForDinnerQueryHandler
     }
 
     public async ValueTask<Result<Page<Reservation>>> Handle(
-        ListReservationsForDinnerQuery request, CancellationToken cancellationToken)
-    {
-        var dinner = await _dinnerRepo.FindById(request.DinnerId.Value.ToString(), cancellationToken);
-        if (dinner is null)
-            return Result.Fail<Page<Reservation>>(
-                new Error.NotFound(ResourceRef.For<BuberDinner.Domain.Dinner.Entities.Dinner>(request.DinnerId)));
-        if (dinner.HostId != request.HostId)
-            return Result.Fail<Page<Reservation>>(
-                new Error.NotFound(ResourceRef.For<BuberDinner.Domain.Dinner.Entities.Dinner>(request.DinnerId))
+        ListReservationsForDinnerQuery request, CancellationToken cancellationToken) =>
+        await LoadOwnedDinnerAsync(request.DinnerId, request.HostId, cancellationToken)
+            .BindAsync(_ => BuildPageAsync(request));
+
+    private async ValueTask<Result<BuberDinner.Domain.Dinner.Entities.Dinner>> LoadOwnedDinnerAsync(
+        DinnerId dinnerId, HostId hostId, CancellationToken cancellationToken) =>
+        (await _dinnerRepo.FindById(dinnerId.Value.ToString(), cancellationToken))
+            .ToResult(new Error.NotFound(ResourceRef.For<BuberDinner.Domain.Dinner.Entities.Dinner>(dinnerId)))
+            .Ensure(
+                d => d.HostId == hostId,
+                new Error.NotFound(ResourceRef.For<BuberDinner.Domain.Dinner.Entities.Dinner>(dinnerId))
                 {
                     Detail = "Dinner does not belong to the specified host.",
                 });
 
+    private ValueTask<Result<Page<Reservation>>> BuildPageAsync(ListReservationsForDinnerQuery request)
+    {
         var pageSize = PageSize.FromRequested(request.Limit);
-
-        System.Guid? afterId = null;
-        if (request.Cursor is { } cursor)
-        {
-            var decoded = CursorCodec.TryDecode<System.Guid>(cursor, fieldName: "cursor");
-            if (!decoded.TryGetValue(out var id, out var cursorError))
-                return Result.Fail<Page<Reservation>>(cursorError);
-            afterId = id;
-        }
-
+        var afterIdResult = DecodeCursor(request.Cursor);
+        if (!afterIdResult.TryGetValue(out var afterId, out var cursorError))
+            return ValueTask.FromResult(Result.Fail<Page<Reservation>>(cursorError));
         var overFetched = _reservationRepo.GetPageForDinner(request.DinnerId, pageSize, afterId);
         var page = PageBuilder.FromOverFetch(overFetched, pageSize, r => r.Id.Value);
-        return Result.Ok(page);
+        return ValueTask.FromResult(Result.Ok(page));
+    }
+
+    private static Result<System.Guid?> DecodeCursor(Cursor? cursor)
+    {
+        if (cursor is not { } c)
+            return Result.Ok<System.Guid?>(null);
+        return CursorCodec.TryDecode<System.Guid>(c, fieldName: "cursor")
+            .Map<System.Guid, System.Guid?>(id => id);
     }
 }

--- a/Domain/src/Dinner/Entities/Dinner.cs
+++ b/Domain/src/Dinner/Entities/Dinner.cs
@@ -56,35 +56,28 @@ public sealed class Dinner : Aggregate<DinnerId>
         MenuId menuId,
         DateTimeOffset startDateTime,
         DateTimeOffset endDateTime,
-        TimeProvider clock)
-    {
-        // Reject default(DateTimeOffset) (year 0001) so an omitted-in-JSON property doesn't
-        // silently produce an aggregate scheduled at 0001-01-01 that still satisfies the
-        // EndDateTime > StartDateTime relative check below.
-        if (startDateTime == default)
-            return Result.Fail<Dinner>(
-                Error.InvalidInput.ForField(nameof(StartDateTime), "dinner.invalid.start-required",
-                    "StartDateTime is required."));
-        if (endDateTime == default)
-            return Result.Fail<Dinner>(
-                Error.InvalidInput.ForField(nameof(EndDateTime), "dinner.invalid.end-required",
-                    "EndDateTime is required."));
-        if (endDateTime <= startDateTime)
-            return Result.Fail<Dinner>(
-                Error.InvalidInput.ForField(nameof(EndDateTime), "dinner.invalid.schedule",
-                    "EndDateTime must be strictly after StartDateTime."));
+        TimeProvider clock) =>
+        s_inputValidator.ValidateToResult(new CreateInputs(
+            name, description, hostId, menuId, startDateTime, endDateTime))
+            .Map(inputs =>
+            {
+                var dinner = new Dinner(
+                    DinnerId.NewUniqueV7(),
+                    inputs.Name, inputs.Description, inputs.HostId, inputs.MenuId,
+                    inputs.StartDateTime, inputs.EndDateTime);
+                dinner.DomainEvents.Add(new DinnerScheduled(
+                    dinner.Id, dinner.HostId, dinner.MenuId,
+                    dinner.StartDateTime, dinner.EndDateTime, clock.GetUtcNow()));
+                return dinner;
+            });
 
-        var dinner = new Dinner(
-            DinnerId.NewUniqueV7(), name, description, hostId, menuId, startDateTime, endDateTime);
-        var validation = s_validator.ValidateToResult(dinner);
-        if (validation.IsFailure)
-            return validation;
-
-        dinner.DomainEvents.Add(new DinnerScheduled(
-            dinner.Id, dinner.HostId, dinner.MenuId,
-            dinner.StartDateTime, dinner.EndDateTime, clock.GetUtcNow()));
-        return Result.Ok(dinner);
-    }
+    private sealed record CreateInputs(
+        Name Name,
+        Description Description,
+        HostId HostId,
+        MenuId MenuId,
+        DateTimeOffset StartDateTime,
+        DateTimeOffset EndDateTime);
 
     private Dinner(
         DinnerId id,
@@ -178,13 +171,22 @@ public sealed class Dinner : Aggregate<DinnerId>
         // Ended and Cancelled are terminal — no transitions configured.
     }
 
-    static readonly InlineValidator<Dinner> s_validator = new()
+    static readonly InlineValidator<CreateInputs> s_inputValidator = new()
     {
-        v => v.RuleFor(x => x.Id).NotEmpty(),
         v => v.RuleFor(x => x.Name).NotEmpty(),
         v => v.RuleFor(x => x.Description).NotEmpty(),
         v => v.RuleFor(x => x.HostId).NotEmpty(),
         v => v.RuleFor(x => x.MenuId).NotEmpty(),
-        v => v.RuleFor(x => x.Status).NotEmpty(),
+        v => v.RuleFor(x => x.StartDateTime).NotEqual(default(DateTimeOffset))
+              .WithErrorCode("dinner.invalid.start-required")
+              .WithMessage("StartDateTime is required."),
+        v => v.RuleFor(x => x.EndDateTime).NotEqual(default(DateTimeOffset))
+              .WithErrorCode("dinner.invalid.end-required")
+              .WithMessage("EndDateTime is required."),
+        v => v.RuleFor(x => x.EndDateTime)
+              .Must((inputs, end) => end > inputs.StartDateTime)
+              .WithErrorCode("dinner.invalid.schedule")
+              .WithMessage("EndDateTime must be strictly after StartDateTime.")
+              .When(x => x.StartDateTime != default && x.EndDateTime != default),
     };
 }

--- a/Domain/src/Reservation/Entities/Reservation.cs
+++ b/Domain/src/Reservation/Entities/Reservation.cs
@@ -25,25 +25,29 @@ public sealed class Reservation : Aggregate<ReservationId>
         DinnerId dinnerId,
         UserId guestUserId,
         int guestCount,
-        TimeProvider clock)
+        TimeProvider clock) =>
+        s_inputValidator.ValidateToResult(new CreateInputs(dinnerId, guestUserId, guestCount))
+            .Map(inputs =>
+            {
+                var reservation = new Reservation(
+                    ReservationId.NewUniqueV7(), inputs.DinnerId, inputs.GuestUserId,
+                    inputs.GuestCount, clock.GetUtcNow());
+                reservation.DomainEvents.Add(new ReservationCreated(
+                    reservation.Id, reservation.DinnerId, reservation.GuestUserId,
+                    reservation.GuestCount, reservation.ReservedAt));
+                return reservation;
+            });
+
+    private sealed record CreateInputs(DinnerId DinnerId, UserId GuestUserId, int GuestCount);
+
+    static readonly InlineValidator<CreateInputs> s_inputValidator = new()
     {
-        if (guestCount <= 0)
-            return Result.Fail<Reservation>(
-                Error.InvalidInput.ForField(nameof(GuestCount), "reservation.invalid.guest-count",
-                    "GuestCount must be positive."));
-
-        var reservation = new Reservation(
-            ReservationId.NewUniqueV7(), dinnerId, guestUserId, guestCount, clock.GetUtcNow());
-
-        var validation = s_validator.ValidateToResult(reservation);
-        if (validation.IsFailure)
-            return validation;
-
-        reservation.DomainEvents.Add(new ReservationCreated(
-            reservation.Id, reservation.DinnerId, reservation.GuestUserId,
-            reservation.GuestCount, reservation.ReservedAt));
-        return Result.Ok(reservation);
-    }
+        v => v.RuleFor(x => x.DinnerId).NotEmpty(),
+        v => v.RuleFor(x => x.GuestUserId).NotEmpty(),
+        v => v.RuleFor(x => x.GuestCount).GreaterThan(0)
+              .WithErrorCode("reservation.invalid.guest-count")
+              .WithMessage("GuestCount must be positive."),
+    };
 
     private Reservation(
         ReservationId id,
@@ -87,13 +91,4 @@ public sealed class Reservation : Aggregate<ReservationId>
     private static void ConfigureMachine(StateMachine<ReservationStatus, ReservationTrigger> machine) =>
         machine.Configure(ReservationStatus.Reserved)
                .Permit(ReservationTrigger.Cancel, ReservationStatus.Cancelled);
-
-    static readonly InlineValidator<Reservation> s_validator = new()
-    {
-        v => v.RuleFor(x => x.Id).NotEmpty(),
-        v => v.RuleFor(x => x.DinnerId).NotEmpty(),
-        v => v.RuleFor(x => x.GuestUserId).NotEmpty(),
-        v => v.RuleFor(x => x.GuestCount).GreaterThan(0),
-        v => v.RuleFor(x => x.Status).NotEmpty(),
-    };
 }


### PR DESCRIPTION
## ROP sweep across the entire codebase

Per audit request, this PR closes every remaining ROP gap at the load-check-act seams of the application and the pre-validation seams of the domain. Two commits, separated for cleaner review:

### Commit 1 — Domain TryCreate refactors (`8dcdf02`)
Apply the `InlineValidator<Inputs>` + `.Map(...)` pattern (established by `MenuReview`) to the remaining two aggregates that still used imperative pre-checks + post-construction aggregate validators.

- **`Dinner.TryCreate`** — folds 3 `if (... == default)` pre-checks + 6 aggregate-shape rules into one `InlineValidator<CreateInputs>`. The schedule rule is `.When(both non-default)`-gated so single bad inputs never double up. `.WithErrorCode` preserves all 3 reason codes the tests assert against.
- **`Reservation.TryCreate`** — removes a **bug-shaped duplication** where `if (guestCount <= 0)` and the validator's `GreaterThan(0)` rule both fired the same effect through two different error paths. Now one rule fires once.

### Commit 2 — Application ROP-ify (`8a883ee`)
Sweep of 8 sites that still used `if (x is null) return Result.Fail(...); if (other check) return Result.Fail(...)`. All converted to `.ToResult(notFoundError).Ensure(predicate, error)` chains following `UpdateMenuReviewCommandHandler.LoadReviewOwnedByAsync`.

| Site | Pattern applied |
|---|---|
| `HostResourceLoader.GetByIdAsync` | trivial `.ToResult()` |
| `GetMenuQueryHandler.Handle` | `.ToResult().Ensure(host)` |
| `GetDinnerQueryHandler.Handle` | `.ToResult().Ensure(host)` |
| `UpdateMenuCommandHandler.LoadMenuAsync` | `.ToResult().Ensure(host)` |
| `ScheduleDinnerCommandHandler.Handle` | helper + `.BindAsync(TryCreate)` + `.TapAsync(Add)` |
| `DinnerTransitionPipeline.ApplyAsync` | helper + `.BindAsync(transition)` + `.TapAsync(Update)` |
| `ListReservationsForDinnerQueryHandler.Handle` | helper + `.BindAsync(BuildPage)`; cursor decode extracted into static `Result<Guid?>` helper |
| `SubmitMenuReviewCommandHandler.EnsureCallerReservedAsync` | `.ToResult().Ensure(status).Map(_ => dinner)` |

### Intentionally left imperative
- **Controllers' `if (ResolveCallerGuestId.IsFailure) return Unauthorized()`** — controllers are the ROP→ActionResult boundary; the current pattern is correct.
- **`Reservation.Cancel`'s reason guard** — single non-duplicated rule; folding it into a validator would be over-engineering.

### Verification
- Build: 0 warnings / 0 errors
- Domain 45/45, Application 1/1, Api 74/74 — all green
- End-to-end `.http` replay across all 30 files: **37/37 requests behave as expected**
- No public-API, error-code, or test changes — pure stylistic refactor

Net delta: **`-18` lines** across 10 files refactored.